### PR TITLE
Update course and lesson download analytics

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -12,6 +12,7 @@ import {NextSeo} from 'next-seo'
 import removeMarkdown from 'remove-markdown'
 import {useViewer} from 'context/viewer-context'
 import {track} from 'utils/analytics'
+import analytics from 'utils/analytics'
 import FolderDownloadIcon from '../icons/folder-download'
 import RSSIcon from '../icons/rss'
 import {convertTimeWithTitles} from 'utils/time-utils'
@@ -452,7 +453,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   />
                 </div>
               )}
-              <div className="flex justify-center md:justify-start space-x-3 my-2 md:m-0 md:mb-2">
+              <div className="flex justify-center my-2 space-x-3 md:justify-start md:m-0 md:mb-2">
                 {access_state && (
                   <div
                     className={`${
@@ -464,7 +465,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 )}
                 {isCourseCompleted && (
                   <div
-                    className="text-white items-center text-center py-1 px-2 rounded-full uppercase font-bold text-xs bg-green-500 cursor-default"
+                    className="items-center px-2 py-1 text-xs font-bold text-center text-white uppercase bg-green-500 rounded-full cursor-default"
                     title="Course completed"
                   >
                     Completed
@@ -609,9 +610,11 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   <Link href={download_url}>
                     <a
                       onClick={() => {
-                        track(`clicked download course`, {
-                          course: course.slug,
-                        })
+                        analytics.events.activityCtaClick(
+                          'course download',
+                          slug,
+                          name,
+                        )
                       }}
                     >
                       <div className="flex flex-row items-center px-4 py-2 text-sm text-gray-600 transition-colors ease-in-out bg-white border border-gray-300 rounded shadow-sm dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 dark:bg-gray-800 dark:border-gray-600 xs:text-base">

--- a/src/components/player/download-control.tsx
+++ b/src/components/player/download-control.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {FunctionComponent} from 'react'
 import axios from 'utils/configured-axios'
-import {track} from 'utils/analytics'
+import analytics from 'utils/analytics'
 import Tippy from '@tippyjs/react'
 import Link from 'next/link'
 
@@ -30,12 +30,10 @@ const DownloadButton: FunctionComponent<DownloadButtonProps> = ({
             window.location.href = data
           })
         }
-        track(`clicked download lesson`, {
-          lesson: slug,
-        })
+        analytics.events.activityCtaClick('lesson download', slug)
       }}
       aria-label="download video"
-      className="w-10 h-10 flex items-center justify-center border-none text-white"
+      className="flex items-center justify-center w-10 h-10 text-white border-none"
       type="button"
     >
       <IconDownload className="w-6" />
@@ -44,7 +42,7 @@ const DownloadButton: FunctionComponent<DownloadButtonProps> = ({
     <Link href="/pricing" passHref>
       <a
         aria-label="become a member to download this lesson"
-        className="w-10 h-10 flex items-center justify-center opacity-50"
+        className="flex items-center justify-center w-10 h-10 opacity-50"
       >
         <IconDownload className="w-6" />
       </a>
@@ -60,7 +58,7 @@ const DownloadControl: FunctionComponent<DownloadControlProps> = ({
     <Tippy
       offset={[0, -2]}
       content={
-        <div className="text-sm bg-gray-900 px-2 py-1 rounded-sm">
+        <div className="px-2 py-1 text-sm bg-gray-900 rounded-sm">
           {download_url
             ? 'Download video'
             : 'Become a member to download this lesson'}

--- a/src/components/search/instructors/filip-hric/index.tsx
+++ b/src/components/search/instructors/filip-hric/index.tsx
@@ -43,20 +43,20 @@ export default function SearchFilipHric({
           />
         }
       />
-      <div className="flex flex-wrap justify-center xl:flex-nowrap gap-4">
+      <div className="flex flex-wrap justify-center gap-4 xl:flex-nowrap">
         <section className="text-center xl:text-left">
-          <h2 className="my-4 lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+          <h2 className="my-4 text-lg font-semibold leading-tight lg:text-2xl sm:text-xl dark:text-white">
             Courses
           </h2>
           <div className="my-4">
             <div className="flex flex-wrap sm:flex-nowrap gap-3 justify-center sm:h-[424px]">
               <VerticalResourceCard
-                className="col-span-1 flex flex-col h-full justify-center text-center sm:w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
+                className="flex flex-col justify-center h-full col-span-1 p-4 text-center bg-white rounded shadow-sm sm:w-64 dark:bg-gray-800 dark:text-gray-200"
                 resource={primaryCourse}
                 as="h3"
               />
               <VerticalResourceCard
-                className="col-span-1 flex flex-col justify-center text-center sm:w-64 bg-white p-4 rounded dark:bg-gray-800 dark:text-gray-200 shadow-sm"
+                className="flex flex-col justify-center col-span-1 p-4 text-center bg-white rounded shadow-sm sm:w-64 dark:bg-gray-800 dark:text-gray-200"
                 resource={secondCourse}
                 as="h3"
               />
@@ -64,10 +64,10 @@ export default function SearchFilipHric({
           </div>
         </section>
         <section className="text-center xl:text-left">
-          <h2 className="my-4 lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+          <h2 className="my-4 text-lg font-semibold leading-tight lg:text-2xl sm:text-xl dark:text-white">
             Articles
           </h2>
-          <div className="grid lg:grid-cols-2 grid-cols-1 gap-3 justify-center max-w-xl mx-auto">
+          <div className="grid justify-center max-w-xl grid-cols-1 gap-3 mx-auto lg:grid-cols-2">
             <HorizontalResourceCard
               className="col-span-2"
               resource={articles.resources[0]}
@@ -170,8 +170,8 @@ const NewExternalTrackedLink: React.FunctionComponent<any> = ({
       analytics.events
         .activityCtaClick(
           'workshop',
-          instructor,
           currentLocation,
+          instructor,
           topic,
           redirectTo,
         )
@@ -206,7 +206,7 @@ const CypressCourseCTA: React.FC<{
     <NewExternalTrackedLink
       eventName="clicked epic react banner"
       params={{currentLocation, instructor, topic, redirectTo}}
-      className="block md:col-span-4 lg:w-full h-full overflow-hidden border-0 border-gray-100 relative text-center"
+      className="relative block h-full overflow-hidden text-center border-0 border-gray-100 md:col-span-4 lg:w-full"
       href={url}
       target="_blank"
       rel="noopener"

--- a/src/utils/analytics/events.ts
+++ b/src/utils/analytics/events.ts
@@ -173,10 +173,10 @@ export const activityExternalLinkClick = (
 /* We implement different CTAs to invite the user to intentinally go to a course or any type of content. This event will help us understand  how CTA's do on different pages */
 export const activityCtaClick = (
   resourceType: string,
-  instructor: string,
   currentLocation: string,
-  topic: string,
-  redirectTo: string,
+  instructor?: string,
+  topic?: string,
+  redirectTo?: string,
 ) =>
   track('clicked CTA', {
     eventGroup: 'activity',


### PR DESCRIPTION
Updates course and lesson download analytics. @garrettdimon mentioned these statistics can be helpful when disputing stripe charge backs.

![charge](https://media3.giphy.com/media/111GaZJtUrzC4o/giphy.gif?cid=1927fc1bjn8by2ufxuw3gn2s7n3ne306r4z84487rnt0b6qt&rid=giphy.gif&ct=g)