### PR TITLE
Fixes EGG-50: fetch resource state from rails and add retired banner

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -619,7 +619,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                       </div>
                     </a>
                   </Link>
-                ) : (
+                ) : state === 'retired' ? null : (
                   <MembershipDialogButton
                     buttonText="Download"
                     title="Become a member to download this course"

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -435,7 +435,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
       />
       <div className="container pb-8 sm:pb-16 dark:text-gray-100">
         {state === 'retired' && (
-          <div className="w-full p-3 text-lg text-orange-800 bg-orange-100 border border-orange-900 rounded-md border-opacity-20">
+          <div className="w-full p-3 mt-4 text-lg text-orange-800 bg-orange-100 border border-orange-900 rounded-md border-opacity-20">
             ⚠️ This course has been retired and might contain outdated
             information.
           </div>
@@ -452,7 +452,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                   />
                 </div>
               )}
-              <div className="flex justify-center md:justify-start space-x-3 my-2 md:m-0 md:mb-2">
+              <div className="flex justify-center my-2 space-x-3 md:justify-start md:m-0 md:mb-2">
                 {access_state && (
                   <div
                     className={`${
@@ -464,7 +464,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                 )}
                 {isCourseCompleted && (
                   <div
-                    className="text-white items-center text-center py-1 px-2 rounded-full uppercase font-bold text-xs bg-green-500 cursor-default"
+                    className="items-center px-2 py-1 text-xs font-bold text-center text-white uppercase bg-green-500 rounded-full cursor-default"
                     title="Course completed"
                   >
                     Completed

--- a/src/components/player/download-control.tsx
+++ b/src/components/player/download-control.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link'
 type DownloadButtonProps = {
   slug: string
   download_url?: string
+  state?: string
 }
 
 type DownloadControlProps = {
@@ -15,11 +16,13 @@ type DownloadControlProps = {
   download_url?: string
   key?: string
   order?: number
+  state?: string
 }
 
 const DownloadButton: FunctionComponent<DownloadButtonProps> = ({
   slug,
   download_url,
+  state,
 }) => {
   return download_url ? (
     <button
@@ -40,7 +43,7 @@ const DownloadButton: FunctionComponent<DownloadButtonProps> = ({
     >
       <IconDownload className="w-6" />
     </button>
-  ) : (
+  ) : state === 'RETIRED' ? null : (
     <Link href="/pricing" passHref>
       <a
         aria-label="become a member to download this lesson"
@@ -55,6 +58,7 @@ const DownloadButton: FunctionComponent<DownloadButtonProps> = ({
 const DownloadControl: FunctionComponent<DownloadControlProps> = ({
   slug,
   download_url,
+  state,
 }) => {
   return (
     <Tippy
@@ -68,7 +72,7 @@ const DownloadControl: FunctionComponent<DownloadControlProps> = ({
       }
     >
       <div>
-        <DownloadButton slug={slug} download_url={download_url} />
+        <DownloadButton slug={slug} download_url={download_url} state={state} />
       </div>
     </Tippy>
   )

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -185,6 +185,7 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
       icon_url
       download_url
       staff_notes_url
+      state
       repo_url
       code_url
       created_at

--- a/src/lib/playlists.ts
+++ b/src/lib/playlists.ts
@@ -150,6 +150,7 @@ export async function loadPlaylist(slug: string, token?: string) {
         published_at
         access_state
         visibility_state
+        state
         tags {
           name
           image_url

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -568,7 +568,7 @@ const Lesson: React.FC<LessonProps> = ({
             />
           </div>
           {withSidePanel && (
-            <div className="col-span-3 flex flex-col dark:bg-gray-800 bg-gray-50">
+            <div className="flex flex-col col-span-3 dark:bg-gray-800 bg-gray-50">
               <PlayerSidebar
                 relatedResources={specialLessons[lesson.slug]}
                 videoResource={lesson}
@@ -581,6 +581,12 @@ const Lesson: React.FC<LessonProps> = ({
       <div className="container max-w-screen-lg py-8 md:py-12 lg:py-16">
         <div className="grid grid-cols-1 gap-8 divide-y lg:grid-cols-1 lg:gap-12 md:divide-transparent divide-gray-50">
           <div className="row-start-1 space-y-6 md:col-span-8 md:row-start-1 md:space-y-8 lg:space-y-10">
+            {lesson.state === 'RETIRED' && (
+              <div className="p-3 -my-4 text-orange-800 bg-orange-100 border border-orange-900 rounded-md textmy--lg md:-my-8 border-opacity-20">
+                ⚠️ This lesson has been retired and might contain outdated
+                information.
+              </div>
+            )}
             <div className="pb-2 space-y-4 sm:pb-8">
               {title && (
                 <h1 className="text-xl font-extrabold leading-tight lg:text-3xl">

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -517,6 +517,7 @@ const Lesson: React.FC<LessonProps> = ({
                     key={lesson.download_url}
                     download_url={lesson.download_url}
                     slug={lesson.slug}
+                    state={lesson.state}
                   />
                 }
                 // poster={lesson.thumb_url}

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -584,7 +584,7 @@ const Lesson: React.FC<LessonProps> = ({
           <div className="row-start-1 space-y-6 md:col-span-8 md:row-start-1 md:space-y-8 lg:space-y-10">
             {lesson.state === 'RETIRED' && (
               <div className="p-3 -my-4 text-orange-800 bg-orange-100 border border-orange-900 rounded-md textmy--lg md:-my-8 border-opacity-20">
-                ⚠️ This lesson has been retired and might contain outdated
+                ⚠️ This lesson is retired and might contain outdated
                 information.
               </div>
             )}


### PR DESCRIPTION
Update course and lesson page to actually show retired banner if resource is in fact retired.



![course banner desktop](https://user-images.githubusercontent.com/6188161/207676683-c5e7ec08-2842-4c1d-9f3d-cd09fe70dd92.png)
![course banner mobile](https://user-images.githubusercontent.com/6188161/207676719-14e2fbb3-90cf-4f01-910c-442b477b2edc.png)

![lesson banner desktop](https://user-images.githubusercontent.com/6188161/207676920-51272d2a-9825-4b71-bf83-2232964089ac.png)
![lesson banner mobile](https://user-images.githubusercontent.com/6188161/207676985-9b128f88-82d7-4569-92d7-d2a1857b7c58.png)

![retired](https://media1.giphy.com/media/3orif6ldAYqcLtXgru/giphy.gif?cid=1927fc1brkadk1cdwk16jaefi2dxrssaq4vospyiwyqn1vii&rid=giphy.gif&ct=g)