### PR TITLE
add redirect to old user page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -160,6 +160,11 @@ const searchRoutes = [
 
 const legacyRoutes = [
   {
+    source: `/user`,
+    destination: `/user/subscription`,
+    permanent: true,
+  },
+  {
     source: `/membership`,
     destination: `/user`,
     permanent: true,


### PR DESCRIPTION
There are emails that have sent out that send learners to `/user`, this will redirect users to `/user/subscription`

![redirect](https://media3.giphy.com/media/oYyNedGfw8CTq00Whz/giphy.gif?cid=1927fc1bdml6ekivbydmq46tisxj4dw69fnle3vozdal8uxf&rid=giphy.gif&ct=g)