### PR TITLE
add invoices list to user subscription page

### DIFF
--- a/src/components/invoices/index.tsx
+++ b/src/components/invoices/index.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import axios from 'utils/configured-axios'
+import {isEmpty} from 'lodash'
+import {format, parseISO} from 'date-fns'
+
+type HeadingProps = React.ComponentPropsWithoutRef<any> & {
+  headingAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'p'
+}
+
+const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
+  const [transactions, setTransactions] = React.useState([])
+  const [transactionsLoading, setTransactionsLoading] = React.useState(true)
+
+  const Heading = headingAs ?? 'p'
+
+  React.useEffect(() => {
+    axios
+      .get(`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/transactions`)
+      .then(({data}) => {
+        setTransactionsLoading(false)
+        setTransactions(data)
+      })
+  }, [])
+
+  return (
+    <main className="py-5 mb-16">
+      {transactionsLoading ? (
+        <div></div>
+      ) : (
+        <div className="max-w-screen-md mx-auto">
+          {isEmpty(transactions) ? (
+            <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
+              No Transactions
+            </Heading>
+          ) : (
+            <div className="flex flex-col space-y-8">
+              <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
+                Transactions
+              </Heading>
+              <div>
+                <ul className="space-y-6">
+                  {transactions.map((transaction: any) => {
+                    return (
+                      <li key={transaction.stripe_transaction_id}>
+                        <div className="flex space-x-4">
+                          <div>
+                            egghead membership: ${transaction.amount / 100}
+                          </div>
+                          <div>
+                            {format(
+                              parseISO(transaction.created_at),
+                              'yyyy/MM/dd',
+                            )}
+                          </div>
+                          <div>
+                            <a
+                              className="w-full px-2 py-1 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md shadow-lg md:w-auto hover:bg-indigo-600 hover:scale-105"
+                              href={`/invoices/${transaction.stripe_transaction_id}`}
+                            >
+                              full invoice
+                            </a>
+                          </div>
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </main>
+  )
+}
+
+export default Invoices

--- a/src/pages/invoices/[stripeTransactionId].tsx
+++ b/src/pages/invoices/[stripeTransactionId].tsx
@@ -7,6 +7,8 @@ import axios from 'utils/configured-axios'
 import Invoice from 'components/pages/invoice'
 import {useRouter} from 'next/router'
 import {useViewer} from '../../context/viewer-context'
+import {ArrowNarrowLeftIcon} from '@heroicons/react/outline'
+import Link from 'next/link'
 
 const tracer = getTracer('invoices-index-page')
 
@@ -41,7 +43,16 @@ const InvoicePage: React.FunctionComponent<any> = ({transactionId}) => {
   }, [])
   return (
     <LoginRequired>
-      <main className="container py-5 mb-16">
+      <main className="container py-5 mb-16 max-w-screen-md">
+        <Link href="/user/subscription">
+          <a>
+            <div className="flex ">
+              {' '}
+              <ArrowNarrowLeftIcon className="flex-shrink-0 mr-2 h-6 w-6" />{' '}
+              Back to Profile
+            </div>
+          </a>
+        </Link>
         {transaction && viewer && (
           <Invoice transaction={transaction} viewer={viewer}></Invoice>
         )}

--- a/src/pages/invoices/index.tsx
+++ b/src/pages/invoices/index.tsx
@@ -1,80 +1,13 @@
 import * as React from 'react'
 import LoginRequired from 'components/login-required'
-import axios from 'utils/configured-axios'
-import {isEmpty} from 'lodash'
-import {format, parseISO} from 'date-fns'
+import Invoices from 'components/invoices'
 
-type HeadingProps = React.ComponentPropsWithoutRef<any> & {
-  headingAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'p'
-}
-
-const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
-  const [transactions, setTransactions] = React.useState([])
-  const [transactionsLoading, setTransactionsLoading] = React.useState(true)
-
-  const Heading = headingAs ?? 'h1'
-
-  React.useEffect(() => {
-    axios
-      .get(`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/transactions`)
-      .then(({data}) => {
-        setTransactionsLoading(false)
-        setTransactions(data)
-      })
-  }, [])
-
+const InvoicesPage: React.FunctionComponent<any> = () => {
   return (
     <LoginRequired>
-      <main className="py-5 mb-16">
-        {transactionsLoading ? (
-          <div></div>
-        ) : (
-          <div className="max-w-screen-md mx-auto">
-            {isEmpty(transactions) ? (
-              <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
-                No Transactions
-              </Heading>
-            ) : (
-              <div className="flex flex-col space-y-8">
-                <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
-                  Transactions
-                </Heading>
-                <div>
-                  <ul className="space-y-6">
-                    {transactions.map((transaction: any) => {
-                      return (
-                        <li key={transaction.stripe_transaction_id}>
-                          <div className="flex space-x-4">
-                            <div>
-                              egghead membership: ${transaction.amount / 100}
-                            </div>
-                            <div>
-                              {format(
-                                parseISO(transaction.created_at),
-                                'yyyy/MM/dd',
-                              )}
-                            </div>
-                            <div>
-                              <a
-                                className="w-full px-2 py-1 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md shadow-lg md:w-auto hover:bg-indigo-600 hover:scale-105"
-                                href={`/invoices/${transaction.stripe_transaction_id}`}
-                              >
-                                full invoice
-                              </a>
-                            </div>
-                          </div>
-                        </li>
-                      )
-                    })}
-                  </ul>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </main>
+      <Invoices headingAs="h1" />
     </LoginRequired>
   )
 }
 
-export default Invoices
+export default InvoicesPage

--- a/src/pages/invoices/index.tsx
+++ b/src/pages/invoices/index.tsx
@@ -19,16 +19,20 @@ const Invoices: React.FunctionComponent<any> = () => {
 
   return (
     <LoginRequired>
-      <main className="container py-5 mb-16">
+      <main className="py-5 mb-16">
         {transactionsLoading ? (
           <div></div>
         ) : (
           <div className="max-w-screen-md mx-auto">
             {isEmpty(transactions) ? (
-              <h1 className="text-2xl font-bold">No Transactions</h1>
+              <h1 className="text-lg font-medium md:font-normal md:text-xl leading-none">
+                No Transactions
+              </h1>
             ) : (
               <div className="flex flex-col space-y-8">
-                <h1 className="text-2xl font-bold">Transactions:</h1>
+                <h1 className="text-lg font-medium md:font-normal md:text-xl leading-none">
+                  Transactions
+                </h1>
                 <div>
                   <ul className="space-y-6">
                     {transactions.map((transaction: any) => {

--- a/src/pages/invoices/index.tsx
+++ b/src/pages/invoices/index.tsx
@@ -4,9 +4,15 @@ import axios from 'utils/configured-axios'
 import {isEmpty} from 'lodash'
 import {format, parseISO} from 'date-fns'
 
-const Invoices: React.FunctionComponent<any> = () => {
+type HeadingProps = React.ComponentPropsWithoutRef<any> & {
+  headingAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'p'
+}
+
+const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
   const [transactions, setTransactions] = React.useState([])
   const [transactionsLoading, setTransactionsLoading] = React.useState(true)
+
+  const Heading = headingAs ?? 'h1'
 
   React.useEffect(() => {
     axios
@@ -25,14 +31,14 @@ const Invoices: React.FunctionComponent<any> = () => {
         ) : (
           <div className="max-w-screen-md mx-auto">
             {isEmpty(transactions) ? (
-              <h1 className="text-lg font-medium md:font-normal md:text-xl leading-none">
+              <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
                 No Transactions
-              </h1>
+              </Heading>
             ) : (
               <div className="flex flex-col space-y-8">
-                <h1 className="text-lg font-medium md:font-normal md:text-xl leading-none">
+                <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
                   Transactions
-                </h1>
+                </Heading>
                 <div>
                   <ul className="space-y-6">
                     {transactions.map((transaction: any) => {

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -9,7 +9,7 @@ import AppLayout from 'components/app/layout'
 import UserLayout from './components/user-layout'
 import {AccountInfoTabContent} from 'components/pages/user'
 import PricingWidget from 'components/pricing/pricing-widget'
-import Invoices from 'pages/invoices'
+import Invoices from 'components/invoices'
 
 type ViewerAccount = {
   stripe_customer_id: string

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -33,8 +33,6 @@ const Account = () => {
   const [account, setAccount] = React.useState<ViewerAccount>()
   const {slug} = getAccountWithSubscription(accounts)
 
-  console.log({account})
-
   React.useEffect(() => {
     const loadAccountForSlug = async (slug: string) => {
       if (slug) {

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -64,7 +64,7 @@ const Account = () => {
           <PricingWidget />
         </>
       )}
-      <Invoices />
+      <Invoices headingAs="h3" />
     </div>
   )
 }

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -9,6 +9,7 @@ import AppLayout from 'components/app/layout'
 import UserLayout from './components/user-layout'
 import {AccountInfoTabContent} from 'components/pages/user'
 import PricingWidget from 'components/pricing/pricing-widget'
+import Invoices from 'pages/invoices'
 
 type ViewerAccount = {
   stripe_customer_id: string
@@ -31,6 +32,8 @@ const Account = () => {
   const {email: currentEmail, accounts, providers} = viewer || {}
   const [account, setAccount] = React.useState<ViewerAccount>()
   const {slug} = getAccountWithSubscription(accounts)
+
+  console.log({account})
 
   React.useEffect(() => {
     const loadAccountForSlug = async (slug: string) => {
@@ -63,6 +66,7 @@ const Account = () => {
           <PricingWidget />
         </>
       )}
+      <Invoices />
     </div>
   )
 }


### PR DESCRIPTION
Updates subscription page with previous transactions. Hoping this helps reduce the number of support requests asking for an invoice..

![invoice](https://media2.giphy.com/media/dmmBhPUnCSF9ibuTEo/giphy.gif?cid=1927fc1bwund49pxxxi3j2y4yfaf9q2j925umkhp8zr9gzop&rid=giphy.gif&ct=g)


![list invoices on subscription page](https://user-images.githubusercontent.com/6188161/208180385-2766344e-077a-4970-8c5f-47d5afc4cd25.png)
![useful link back to subscription page](https://user-images.githubusercontent.com/6188161/208180228-2cb835a6-94fb-4dae-bd69-47c6cd564c8f.png)
