### PR TITLE
Fixes EGG-58: mobile styles for invoices page

### DIFF
--- a/src/components/pages/invoice/index.tsx
+++ b/src/components/pages/invoice/index.tsx
@@ -30,8 +30,8 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
         </button>
       </div>
       <div className="border border-gray-200 print:border-none rounded-sm">
-        <div className="px-10 py-16 print:text-black">
-          <div className="grid grid-cols-3 w-full justify-between items-start">
+        <div className="p-4 md:px-10 md:py-16 print:text-black">
+          <div className="grid md:grid-cols-3 print:grid-cols-3 w-full justify-between items-start">
             <div className="col-span-2 flex items-center">
               <div className="w-10 mr-2">
                 <Image src={Eggo} alt="" />
@@ -51,8 +51,8 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
               972-992-5951
             </div>
           </div>
-          <div className="grid grid-cols-3 pb-48 mt-6">
-            <div className="col-span-2">
+          <div className="grid md:grid-cols-3 print:grid-cols-3 mt-6">
+            <div className="md:col-span-2 print:col-span-2">
               <h5 className="text-2xl font-bold mb-2">Invoice</h5>
               Invoice ID: <strong>{transaction.transaction.source.id}</strong>
               <br />
@@ -64,7 +64,7 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
                 )}
               </strong>
             </div>
-            <div className="pt-13">
+            <div className="mt-8 md:mt-0 print:mt-0">
               <h5 className="uppercase text-xs mb-2 text-gray-500">
                 Invoice For
               </h5>
@@ -74,17 +74,18 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
               </div>
               <br className="print:hidden" />
               <textarea
-                className={`form-textarea dark:text-black text-black placeholder-gray-700 border border-gray-200 bg-gray-50 w-full h-full print:p-0 print:border-none resize-none print:bg-transparent ${
+                className={`form-textarea dark:text-black text-black placeholder-gray-700 border border-gray-200 bg-gray-50 w-full print:p-0 print:border-none resize-none print:bg-transparent ${
                   invoiceInfo ? '' : 'print:hidden'
                 }`}
                 value={invoiceInfo}
+                rows={5}
                 onChange={(e) => setInvoiceInfo(e.target.value)}
                 placeholder="Enter company info here (optional)"
               />
             </div>
           </div>
-          <table className="table-auto w-full text-left">
-            <thead className="table-header-group">
+          <table className="table-auto w-full text-left md:mt-32 print:mt-32 mt-8">
+            <thead className="table-header-group whitespace-nowrap">
               <tr className="table-row">
                 <th>Description</th>
                 <th>Unit Price</th>

--- a/src/components/pages/invoice/index.tsx
+++ b/src/components/pages/invoice/index.tsx
@@ -30,7 +30,7 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
         </button>
       </div>
       <div className="border border-gray-200 print:border-none rounded-sm">
-        <div className="px-10 py-16">
+        <div className="px-10 py-16 print:text-black">
           <div className="grid grid-cols-3 w-full justify-between items-start">
             <div className="col-span-2 flex items-center">
               <div className="w-10 mr-2">
@@ -51,7 +51,7 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
               972-992-5951
             </div>
           </div>
-          <div className="grid grid-cols-3 pb-64">
+          <div className="grid grid-cols-3 pb-48 mt-6">
             <div className="col-span-2">
               <h5 className="text-2xl font-bold mb-2">Invoice</h5>
               Invoice ID: <strong>{transaction.transaction.source.id}</strong>
@@ -68,14 +68,13 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
               <h5 className="uppercase text-xs mb-2 text-gray-500">
                 Invoice For
               </h5>
-              <div>
-                {viewer.full_name}
-                <br />
-                {viewer.email}
+              <div className="space-y-2">
+                <div>{viewer.full_name}</div>
+                <div>{viewer.email}</div>
               </div>
               <br className="print:hidden" />
               <textarea
-                className={`form-textarea dark:text-black text-black placeholder-gray-700 border border-gray-200 bg-gray-50 w-full h-full print:p-0 print:border-none print:bg-transparent ${
+                className={`form-textarea dark:text-black text-black placeholder-gray-700 border border-gray-200 bg-gray-50 w-full h-full print:p-0 print:border-none resize-none print:bg-transparent ${
                   invoiceInfo ? '' : 'print:hidden'
                 }`}
                 value={invoiceInfo}
@@ -116,7 +115,7 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
               })}
             </tbody>
           </table>
-          <div className="flex flex-col items-end py-16">
+          <div className="flex flex-col items-end mt-16">
             <div>
               <span className="mr-3">Total</span>
               <strong>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -112,7 +112,9 @@ const App: React.FC<AppProps> = ({Component, pageProps}) => {
                 <MDXProvider components={mdxComponents}>
                   {getLayout(Component, pageProps)}
                 </MDXProvider>
-                <ReactQueryDevtools />
+                <div className="print:hidden">
+                  <ReactQueryDevtools />
+                </div>
               </QueryClientProvider>
             </CioProvider>
           </LogRocketProvider>

--- a/src/pages/invoices/[stripeTransactionId].tsx
+++ b/src/pages/invoices/[stripeTransactionId].tsx
@@ -45,7 +45,7 @@ const InvoicePage: React.FunctionComponent<any> = ({transactionId}) => {
     <LoginRequired>
       <main className="container py-5 mb-16 max-w-screen-md">
         <Link href="/user/subscription">
-          <a>
+          <a className="print:hidden">
             <div className="flex ">
               {' '}
               <ArrowNarrowLeftIcon className="flex-shrink-0 mr-2 h-6 w-6" />{' '}


### PR DESCRIPTION
<details>
  <summary>Mobile styles before:</summary>
  <img width="390" src="https://user-images.githubusercontent.com/1519448/208200517-e53dca9b-87c2-47ca-bbe7-1363732543c6.jpg">
</details>
<details>
  <summary>PDF styles before:</summary>
  <img width="1024" src="https://user-images.githubusercontent.com/1519448/208200520-d89fd333-82b4-4bb8-9578-4e2e929ada88.jpg">
</details>
<details>
  <summary>Mobile styles after:</summary>
  <img width="390" src="https://user-images.githubusercontent.com/1519448/208200557-776031f5-5808-483b-b541-9aad4b5a461b.jpg">
</details>
<details>
  <summary>PDF styles after:</summary>
  <img width="1024" src="https://user-images.githubusercontent.com/1519448/208200558-c87f8131-a192-4fd4-8566-e6774f52c825.jpg">
</details>


![Life Lol GIF by America's Funniest Home Videos](https://user-images.githubusercontent.com/1519448/208200677-0a092e34-233e-4d35-9a66-d73cd84eb7d5.gif)
