### PR TITLE
fixes EGG-51: cleanup user subscription tab

### DIFF
--- a/src/components/invoices/index.tsx
+++ b/src/components/invoices/index.tsx
@@ -23,11 +23,11 @@ const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
   }, [])
 
   return (
-    <main className="py-5 mb-16">
+    <main className="mt-16">
       {transactionsLoading ? (
         <div></div>
       ) : (
-        <div className="max-w-screen-md mx-auto">
+        <div>
           {isEmpty(transactions) ? (
             <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
               No Transactions

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -97,7 +97,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         )}
         {(subscriptionData?.subscription?.cancel_at_period_end ||
           subscriptionData?.portalUrl) && (
-          <div className="p-4 bg-primary-2 text-accents-3 rounded-b-md">
+          <div className="bg-primary-2 text-accents-3 rounded-b-md mt-6">
             <div className="flex flex-col items-start justify-between sm:items-center">
               {subscriptionData?.subscription?.cancel_at_period_end && (
                 <p className="pb-4 sm:pb-0">

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -52,7 +52,7 @@ const Account = () => {
         <div className="relative flex justify-center">
           <Spinner className="w-6 h-6 text-gray-600" />
         </div>
-      ) : account ? (
+      ) : account?.stripe_customer_id ? (
         <>
           <ItemWrapper title="Subscription">
             <SubscriptionDetails

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -9,6 +9,7 @@ import AppLayout from 'components/app/layout'
 import UserLayout from './components/user-layout'
 import PricingWidget from 'components/pricing/pricing-widget'
 import Invoices from 'components/invoices'
+import Spinner from 'components/spinner'
 
 type ViewerAccount = {
   stripe_customer_id: string
@@ -48,7 +49,9 @@ const Account = () => {
   return (
     <div>
       {accountIsLoading ? (
-        <p className="text-center text-white">Loading...</p>
+        <div className="relative flex justify-center">
+          <Spinner className="w-6 h-6 text-gray-600" />
+        </div>
       ) : account ? (
         <>
           <ItemWrapper title="Subscription">

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -7,7 +7,6 @@ import {loadAccount} from 'lib/accounts'
 import {ItemWrapper} from 'components/pages/user/components/widget-wrapper'
 import AppLayout from 'components/app/layout'
 import UserLayout from './components/user-layout'
-import {AccountInfoTabContent} from 'components/pages/user'
 import PricingWidget from 'components/pricing/pricing-widget'
 import Invoices from 'components/invoices'
 
@@ -32,26 +31,34 @@ const Account = () => {
   const {email: currentEmail, accounts, providers} = viewer || {}
   const [account, setAccount] = React.useState<ViewerAccount>()
   const {slug} = getAccountWithSubscription(accounts)
+  const [accountIsLoading, setAccountIsLoading] = React.useState<boolean>(true)
+
+  const loadAccountForSlug = async (slug: string) => {
+    if (slug) {
+      const account: any = await loadAccount(slug, authToken)
+      setAccount(account)
+    }
+    setAccountIsLoading(false)
+  }
 
   React.useEffect(() => {
-    const loadAccountForSlug = async (slug: string) => {
-      if (slug) {
-        const account: any = await loadAccount(slug, authToken)
-        setAccount(account)
-      }
-    }
     loadAccountForSlug(slug)
   }, [slug, authToken])
 
   return (
     <div>
-      {account ? (
-        <ItemWrapper title="Subscription">
-          <SubscriptionDetails
-            stripeCustomerId={account.stripe_customer_id}
-            slug={slug}
-          />
-        </ItemWrapper>
+      {accountIsLoading ? (
+        <p className="text-center text-white">Loading...</p>
+      ) : account ? (
+        <>
+          <ItemWrapper title="Subscription">
+            <SubscriptionDetails
+              stripeCustomerId={account.stripe_customer_id}
+              slug={slug}
+            />
+          </ItemWrapper>
+          <Invoices headingAs="h3" />
+        </>
       ) : (
         <>
           <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
@@ -64,7 +71,6 @@ const Account = () => {
           <PricingWidget />
         </>
       )}
-      <Invoices headingAs="h3" />
     </div>
   )
 }


### PR DESCRIPTION
This fixes the flashing of `PricingWidget` before `account` gets loaded.
Also minor styles tweaking.

<details>
  <summary>Before:</summary>
  <img width="1000" src="https://user-images.githubusercontent.com/1519448/208757159-854acfe2-8237-4dca-8eb1-7cd5830144f9.gif">
</details>
<details>
  <summary>After:</summary>
  <img width="1000" src="https://user-images.githubusercontent.com/1519448/208757147-6a5a0307-83f0-4357-891f-4e9ea9459c5f.gif">
</details>

![Novak Djokovic Sport GIF by Tennis Channel](https://user-images.githubusercontent.com/1519448/208757819-431fdc1e-a7e4-4054-80b4-b96d73d6bb5d.gif)
