### PR TITLE
Fixes EGG-59: bug with Jumbotrone

### DIFF
--- a/src/components/pages/home/jumbotron.tsx
+++ b/src/components/pages/home/jumbotron.tsx
@@ -39,27 +39,6 @@ const Jumbotron: React.FC<any> = ({data}) => {
                   <PlayIcon className="w-4 text-black" />
                 </div>
               </div>
-              {/* <div
-                aria-hidden
-                className="lg:hidden flex flex-shrink-0 relative items-center justify-center p-5"
-              >
-                <Image
-                  src={resource.image}
-                  alt={resource.title}
-                  width={240}
-                  height={240}
-                  quality={100}
-                  loading="eager"
-                  priority
-                  className="group-hover:scale-95 group-hover:opacity-90 transition-all ease-in-out duration-300"
-                />
-                <div
-                  aria-hidden
-                  className="absolute flex items-center justify-center group-hover:opacity-100 opacity-0 group-hover:scale-100 scale-0 transition-all ease-in-out duration-300 w-10 h-10 rounded-full bg-white bg-opacity-80 shadow-smooth"
-                >
-                  <PlayIcon className="w-4 text-black" />
-                </div>
-              </div> */}
               <div>
                 <p className="uppercase font-mono text-xs pb-1 opacity-80">
                   Fresh Course

--- a/src/components/pages/home/jumbotron.tsx
+++ b/src/components/pages/home/jumbotron.tsx
@@ -6,11 +6,7 @@ import PlayIcon from 'components/pages/courses/play-icon'
 const Jumbotron: React.FC<any> = ({data}) => {
   const resource = data.resources[0]
   return (
-    <div
-      onClick={() => {
-        console.log(resource.tag.name)
-      }}
-    >
+    <div>
       <ResourceLink
         location="jumbotron"
         path={resource.path}
@@ -21,10 +17,10 @@ const Jumbotron: React.FC<any> = ({data}) => {
       >
         <header className="md:aspect-w-16 md:aspect-h-6 relative h-full rounded-b-lg text-white ">
           <div className="flex items-center justify-center relative z-10 md:pb-16 pb-32 md:px-0 px-5 md:pt-0 pt-10">
-            <div className="w-full lg:max-w-screen-lg md:max-w-screen-sm flex md:flex-row flex-col items-center justify-center md:text-left text-center lg:pt-0 md:pt-10">
+            <div className="w-full lg:max-w-screen-lg md:max-w-screen-sm flex md:flex-row flex-col items-center justify-center md:text-left text-center md:pt-8 md:px-5 xl:px-0">
               <div
                 aria-hidden
-                className="hidden flex-shrink-0 relative lg:flex items-center justify-center p-5"
+                className="flex-shrink-0 relative flex items-center justify-center p-5 w-[240px] lg:w-[300px] xl:w-[360px]"
               >
                 <Image
                   src={resource.image}
@@ -43,7 +39,7 @@ const Jumbotron: React.FC<any> = ({data}) => {
                   <PlayIcon className="w-4 text-black" />
                 </div>
               </div>
-              <div
+              {/* <div
                 aria-hidden
                 className="lg:hidden flex flex-shrink-0 relative items-center justify-center p-5"
               >
@@ -63,12 +59,12 @@ const Jumbotron: React.FC<any> = ({data}) => {
                 >
                   <PlayIcon className="w-4 text-black" />
                 </div>
-              </div>
-              <div className="md:pt-10">
+              </div> */}
+              <div>
                 <p className="uppercase font-mono text-xs pb-1 opacity-80">
                   Fresh Course
                 </p>
-                <h1 className="md:pt-0 pt-2 leading-tighter lg:text-3xl sm:text-2xl text-xl tracking-tight font-bold">
+                <h1 className="md:pt-0 pt-2 leading-tighter lg:text-3xl sm:text-2xl md:text-xl text-xl tracking-tight font-bold">
                   {resource.title}
                 </h1>
                 <div className="flex items-center md:justify-start justify-center py-4">
@@ -97,7 +93,7 @@ const Jumbotron: React.FC<any> = ({data}) => {
             layout="fill"
             priority={true}
             quality={100}
-            className="pointer-events-none md:object-contain object-cover"
+            className="pointer-events-none object-cover"
           />
         </header>
       </ResourceLink>


### PR DESCRIPTION
This fixes responsive styles:

<details>
  <summary>Before:</summary>
  <img width="1320" src="https://user-images.githubusercontent.com/1519448/208774440-efa18e2c-658f-4e74-b5c4-e8f706c0c4b0.gif">
</details>
<details>
  <summary>After:</summary>
  <img width="1320" src="https://user-images.githubusercontent.com/1519448/208774422-871303e1-82fe-482f-a89b-6c49f690c45e.gif">
</details>

Also fixed this error caused by weird `console.log` in `onClick`:
![weird-onclick](https://user-images.githubusercontent.com/1519448/208774668-a343bbc6-daf4-49db-9faf-9847acf79b1a.jpg)

![Nba Playoffs Omg GIF by NBA](https://user-images.githubusercontent.com/1519448/208774945-a49cc8e5-02ec-4f61-af67-99ed22d3a352.gif)
