### PR TITLE
fixes EGG-98: add darkmode styles for account transfer modal

### DIFF
--- a/src/components/team/transfer-ownership-confirm-dialog.tsx
+++ b/src/components/team/transfer-ownership-confirm-dialog.tsx
@@ -28,7 +28,7 @@ const TransferOwnershipConfirmDialog: React.FunctionComponent<DialogProps> = ({
       <DialogOverlay isOpen={isOpen} onDismiss={onClose}>
         <DialogContent
           aria-label="Confirm removing team member"
-          className="bg-white rounded-md border-gray-400 p-8"
+          className="dark:bg-gray-900 bg-white rounded-md border-gray-400 p-8 w-96 lg:w-1/3 "
         >
           <div className="flex justify-center relative mb-6">
             <h3 className="text-xl font-medium">Are you sure?</h3>
@@ -40,7 +40,7 @@ const TransferOwnershipConfirmDialog: React.FunctionComponent<DialogProps> = ({
             <p>
               Confirm that you would like to transfer your ownership of this
               team account to{' '}
-              <strong className="font-semibold text-gray-800">
+              <strong className="font-semibold text-gray-800 dark:text-white">
                 {inviteeEmail}
               </strong>{' '}
               by re-typing their email. Then click 'Confirm'.
@@ -60,7 +60,7 @@ const TransferOwnershipConfirmDialog: React.FunctionComponent<DialogProps> = ({
               disabled={loading}
               className="bg-gray-50 dark:bg-gray-800 focus:outline-none focus:shadow-outline border border-gray-100 dark:border-gray-700 rounded-md py-2 px-4 block w-full appearance-none leading-normal"
             />
-            <div className="flex flex-row justify-end space-x-2">
+            <div className="flex flex-row justify-center space-x-2">
               <button
                 disabled={loading || !current.matches({open: 'confirmable'})}
                 onClick={onConfirm}


### PR DESCRIPTION
When transferring team account I noticed that dark mode styles on the confirmation modal weren't applied. This fixes that and also adds slight tweak to modal size for readability

![readability](https://media1.giphy.com/media/WoWm8YzFQJg5i/giphy.gif?cid=1927fc1b8vgp41b3zigjqqzoj73vjjn9hyh8nl17mw4z5lsc&rid=giphy.gif&ct=g) 


## Before
![mobile - modal before change](https://user-images.githubusercontent.com/6188161/210446181-01002714-055c-4599-a50e-02337a95baef.png)
![desktop - modal before change](https://user-images.githubusercontent.com/6188161/210446188-1e1d323e-8da3-4196-bf44-26c888f236de.png)

## After
![mobile - modal after change](https://user-images.githubusercontent.com/6188161/210446301-b7a3b089-787f-469a-8615-1ab21f8450a8.png)
![desktop - modal after change](https://user-images.githubusercontent.com/6188161/210446137-291d7a85-24d8-41a6-a51e-5ff6af9ad2cf.png)

