### PR TITLE
Fixes EGG-101: provide a direct link to invoice after purchase

### DIFF
--- a/src/components/invoices/index.tsx
+++ b/src/components/invoices/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import axios from 'utils/configured-axios'
 import {isEmpty} from 'lodash'
 import {format, parseISO} from 'date-fns'
+import Spinner from 'components/spinner'
+import Link from 'next/link'
 
 type HeadingProps = React.ComponentPropsWithoutRef<any> & {
   headingAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'p'
@@ -20,57 +22,53 @@ const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
         setTransactionsLoading(false)
         setTransactions(data)
       })
+      .catch((error) => console.log({error}))
   }, [])
 
-  return (
-    <main className="mt-16">
-      {transactionsLoading ? (
-        <div></div>
-      ) : (
-        <div>
-          {isEmpty(transactions) ? (
-            <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
-              No Transactions
-            </Heading>
-          ) : (
-            <div className="flex flex-col space-y-8">
-              <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
-                Transactions
-              </Heading>
-              <div>
-                <ul className="space-y-6">
-                  {transactions.map((transaction: any) => {
-                    return (
-                      <li key={transaction.stripe_transaction_id}>
-                        <div className="flex space-x-4">
-                          <div>
-                            egghead membership: ${transaction.amount / 100}
-                          </div>
-                          <div>
-                            {format(
-                              parseISO(transaction.created_at),
-                              'yyyy/MM/dd',
-                            )}
-                          </div>
-                          <div>
-                            <a
-                              className="w-full px-2 py-1 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md shadow-lg md:w-auto hover:bg-indigo-600 hover:scale-105"
-                              href={`/invoices/${transaction.stripe_transaction_id}`}
-                            >
-                              full invoice
-                            </a>
-                          </div>
-                        </div>
-                      </li>
-                    )
-                  })}
-                </ul>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-    </main>
+  return transactionsLoading ? (
+    <div className="flex justify-center">
+      <Spinner className="w-6 h-6 text-gray-600" />
+    </div>
+  ) : isEmpty(transactions) ? (
+    <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none text-center">
+      No Transactions
+    </Heading>
+  ) : (
+    <div className="flex flex-col space-y-8">
+      <Heading className="text-lg font-medium md:font-normal md:text-xl leading-none">
+        Transactions
+      </Heading>
+      <div>
+        <ul className="space-y-6">
+          {transactions.map((transaction: any) => {
+            return (
+              <li key={transaction.stripe_transaction_id}>
+                <div className="flex space-x-4">
+                  <div>egghead membership: ${transaction.amount / 100}</div>
+                  <div>
+                    {format(parseISO(transaction.created_at), 'yyyy/MM/dd')}
+                  </div>
+                  <div>
+                    <Link
+                      href={{
+                        pathname: `/invoices/${transaction.stripe_transaction_id}`,
+                        query: {
+                          backToProfile: true,
+                        },
+                      }}
+                    >
+                      <a className="w-full px-2 py-1 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md shadow-lg md:w-auto hover:bg-indigo-600 hover:scale-105">
+                        full invoice
+                      </a>
+                    </Link>
+                  </div>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </div>
   )
 }
 

--- a/src/components/invoices/index.tsx
+++ b/src/components/invoices/index.tsx
@@ -52,9 +52,6 @@ const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
                     <Link
                       href={{
                         pathname: `/invoices/${transaction.stripe_transaction_id}`,
-                        query: {
-                          backToProfile: true,
-                        },
                       }}
                     >
                       <a className="w-full px-2 py-1 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md shadow-lg md:w-auto hover:bg-indigo-600 hover:scale-105">

--- a/src/components/invoices/index.tsx
+++ b/src/components/invoices/index.tsx
@@ -50,9 +50,7 @@ const Invoices: React.FunctionComponent<HeadingProps> = ({headingAs}) => {
                   </div>
                   <div>
                     <Link
-                      href={{
-                        pathname: `/invoices/${transaction.stripe_transaction_id}`,
-                      }}
+                      href={`/invoices/${transaction.stripe_transaction_id}`}
                     >
                       <a className="w-full px-2 py-1 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md shadow-lg md:w-auto hover:bg-indigo-600 hover:scale-105">
                         full invoice

--- a/src/components/pages/confirm/membership/index.tsx
+++ b/src/components/pages/confirm/membership/index.tsx
@@ -186,10 +186,11 @@ const ExistingMemberConfirmation: React.FC<{session: any}> = ({session}) => {
   const [transactionsLoading, setTransactionsLoading] = React.useState(true)
 
   const invoiceUrl =
-    (!isEmpty(transactions) &&
-      last(transactions) &&
-      get(last(transactions), 'stripe_transaction_id')) ||
-    null
+    !isEmpty(transactions) &&
+    last(transactions) &&
+    get(last(transactions), 'stripe_transaction_id')
+      ? `/invoices/${last(transactions).stripe_transaction_id}`
+      : null
 
   React.useEffect(() => {
     axios

--- a/src/components/pages/confirm/membership/index.tsx
+++ b/src/components/pages/confirm/membership/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import useLastResource from 'hooks/use-last-resource'
-import {isEmpty} from 'lodash'
+import {isEmpty, last} from 'lodash'
+import axios from 'utils/configured-axios'
 import Link from 'next/link'
 import Image from 'next/image'
 import Spinner from 'components/spinner'
@@ -181,6 +182,18 @@ const StartLearning: React.FC = () => {
 
 const ExistingMemberConfirmation: React.FC<{session: any}> = ({session}) => {
   const {theme, setTheme} = useTheme()
+  const [transactions, setTransactions] = React.useState([])
+  const [transactionsLoading, setTransactionsLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    axios
+      .get(`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/transactions`)
+      .then(({data}) => {
+        setTransactionsLoading(false)
+        setTransactions(data)
+      })
+      .catch((error) => console.log({error}))
+  }, [])
 
   React.useEffect(() => {
     setTheme('dark')
@@ -204,9 +217,18 @@ const ExistingMemberConfirmation: React.FC<{session: any}> = ({session}) => {
           </>
         }
       />
-
+      <div className="flex justify-center h-12">
+        {transactionsLoading ? (
+          <Spinner className="w-6 h-6 text-gray-600" />
+        ) : !isEmpty(transactions) ? (
+          <Link href={`/invoices/${last(transactions).stripe_transaction_id}`}>
+            <a className="inline-block px-4 py-3 text-white bg-blue-600 border-0 rounded focus:outline-none hover:bg-blue-700 duration-100">
+              Get your invoice
+            </a>
+          </Link>
+        ) : null}
+      </div>
       <PostPurchase email={session?.email} />
-
       <div className="space-y-10">
         <PopularTopics />
         <LastResource />

--- a/src/components/pages/confirm/membership/index.tsx
+++ b/src/components/pages/confirm/membership/index.tsx
@@ -185,12 +185,10 @@ const ExistingMemberConfirmation: React.FC<{session: any}> = ({session}) => {
   const [transactions, setTransactions] = React.useState([])
   const [transactionsLoading, setTransactionsLoading] = React.useState(true)
 
-  const invoiceUrl =
-    !isEmpty(transactions) &&
-    last(transactions) &&
-    get(last(transactions), 'stripe_transaction_id')
-      ? `/invoices/${last(transactions).stripe_transaction_id}`
-      : null
+  const lastTransactionId = get(last(transactions), 'stripe_transaction_id')
+  const invoiceUrl = lastTransactionId
+    ? `/invoices/${lastTransactionId['stripe_transaction_id']}`
+    : null
 
   React.useEffect(() => {
     axios

--- a/src/components/pages/confirm/membership/index.tsx
+++ b/src/components/pages/confirm/membership/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import useLastResource from 'hooks/use-last-resource'
-import {isEmpty, last} from 'lodash'
+import {isEmpty, last, get} from 'lodash'
 import axios from 'utils/configured-axios'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -185,6 +185,12 @@ const ExistingMemberConfirmation: React.FC<{session: any}> = ({session}) => {
   const [transactions, setTransactions] = React.useState([])
   const [transactionsLoading, setTransactionsLoading] = React.useState(true)
 
+  const invoiceUrl =
+    (!isEmpty(transactions) &&
+      last(transactions) &&
+      get(last(transactions), 'stripe_transaction_id')) ||
+    null
+
   React.useEffect(() => {
     axios
       .get(`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/transactions`)
@@ -220,8 +226,8 @@ const ExistingMemberConfirmation: React.FC<{session: any}> = ({session}) => {
       <div className="flex justify-center h-12">
         {transactionsLoading ? (
           <Spinner className="w-6 h-6 text-gray-600" />
-        ) : !isEmpty(transactions) ? (
-          <Link href={`/invoices/${last(transactions).stripe_transaction_id}`}>
+        ) : invoiceUrl ? (
+          <Link href={invoiceUrl}>
             <a className="inline-block px-4 py-3 text-white bg-blue-600 border-0 rounded focus:outline-none hover:bg-blue-700 duration-100">
               Get your invoice
             </a>

--- a/src/components/pages/invoice/index.tsx
+++ b/src/components/pages/invoice/index.tsx
@@ -3,6 +3,7 @@ import Eggo from '../../images/eggo.svg'
 import Image from 'next/image'
 import {useLocalStorage} from 'react-use'
 import {format} from 'date-fns'
+import cx from 'classnames'
 
 type InvoiceProps = {
   viewer: any
@@ -29,7 +30,7 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
           Download PDF or Print
         </button>
       </div>
-      <div className="border border-gray-200 print:border-none rounded-sm">
+      <div className="border border-gray-200 print:border-none rounded-md">
         <div className="p-4 md:px-10 md:py-16 print:text-black">
           <div className="grid md:grid-cols-3 print:grid-cols-3 w-full justify-between items-start">
             <div className="col-span-2 flex items-center">
@@ -72,11 +73,20 @@ const Invoice: React.FunctionComponent<InvoiceProps> = ({
                 <div>{viewer.full_name}</div>
                 <div>{viewer.email}</div>
               </div>
-              <br className="print:hidden" />
+              <br />
+              <h5
+                className={cx(
+                  'uppercase text-xs mb-2 text-gray-500 hidden',
+                  invoiceInfo ? 'print:block' : 'print:hidden',
+                )}
+              >
+                Additional Info:
+              </h5>
               <textarea
-                className={`form-textarea dark:text-black text-black placeholder-gray-700 border border-gray-200 bg-gray-50 w-full print:p-0 print:border-none resize-none print:bg-transparent ${
-                  invoiceInfo ? '' : 'print:hidden'
-                }`}
+                className={cx(
+                  'form-textarea dark:text-black text-black placeholder-gray-700 border border-gray-200 bg-gray-50 w-full print:p-0 print:border-none resize-none rounded-md print:bg-transparent',
+                  !invoiceInfo && 'print:hidden',
+                )}
                 value={invoiceInfo}
                 rows={5}
                 onChange={(e) => setInvoiceInfo(e.target.value)}

--- a/src/pages/invoices/[stripeTransactionId].tsx
+++ b/src/pages/invoices/[stripeTransactionId].tsx
@@ -7,8 +7,6 @@ import axios from 'utils/configured-axios'
 import Invoice from 'components/pages/invoice'
 import {useRouter} from 'next/router'
 import {useViewer} from '../../context/viewer-context'
-import {ArrowNarrowLeftIcon} from '@heroicons/react/outline'
-import Link from 'next/link'
 
 const tracer = getTracer('invoices-index-page')
 
@@ -44,15 +42,6 @@ const InvoicePage: React.FunctionComponent<any> = ({transactionId}) => {
   return (
     <LoginRequired>
       <main className="container py-5 mb-16 max-w-screen-md">
-        <Link href="/user/subscription">
-          <a className="print:hidden">
-            <div className="flex ">
-              {' '}
-              <ArrowNarrowLeftIcon className="flex-shrink-0 mr-2 h-6 w-6" />{' '}
-              Back to Profile
-            </div>
-          </a>
-        </Link>
         {transaction && viewer && (
           <Invoice transaction={transaction} viewer={viewer}></Invoice>
         )}

--- a/src/pages/invoices/index.tsx
+++ b/src/pages/invoices/index.tsx
@@ -5,7 +5,11 @@ import Invoices from 'components/invoices'
 const InvoicesPage: React.FunctionComponent<any> = () => {
   return (
     <LoginRequired>
-      <Invoices headingAs="h1" />
+      <main className="mt-16">
+        <div className="container">
+          <Invoices headingAs="h1" />
+        </div>
+      </main>
     </LoginRequired>
   )
 }

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -62,7 +62,9 @@ const Account = () => {
               slug={slug}
             />
           </ItemWrapper>
-          <Invoices headingAs="h3" />
+          <div className="mt-16">
+            <Invoices headingAs="h3" />
+          </div>
         </>
       ) : (
         <>

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -34,6 +34,8 @@ const Account = () => {
   const {slug} = getAccountWithSubscription(accounts)
   const [accountIsLoading, setAccountIsLoading] = React.useState<boolean>(true)
 
+  console.log({account})
+
   const loadAccountForSlug = async (slug: string) => {
     if (slug) {
       const account: any = await loadAccount(slug, authToken)


### PR DESCRIPTION
![22](https://user-images.githubusercontent.com/1519448/211259821-7dd90455-9d51-4b8a-a34d-e47809dd6fb7.gif)

Actually, problem is not solved - after purchase transactions are not immediately available, so call `axios.get(`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/transactions`)` returns the data after about ~1 min (our db  processing time?). It means that on the MembershipConfirmation screen that user gets in browser just after purchase completed (and it redirects from stripe portal) `transactions` data is not loaded.
Is there a way to get `stripe_transaction_id` immediately? Can it be passed along with with redirect from stripe portal somehow?

No funny GIF for now 🥸