### PR TITLE
Fixes EGG-86: continue enhancing the "what I've viewed" functionality

### DIFF
--- a/src/components/card/search-hit-resource-card.tsx
+++ b/src/components/card/search-hit-resource-card.tsx
@@ -16,6 +16,7 @@ import {CardResource} from 'types'
 import {Textfit} from 'react-textfit'
 import ReactMarkdown from 'react-markdown'
 import useFitText from 'use-fit-text'
+import CheckIcon from 'components/icons/check'
 
 const SearchHitResourceCard: React.FC<{
   resource: CardResource
@@ -23,6 +24,7 @@ const SearchHitResourceCard: React.FC<{
   describe?: boolean
   className?: string
   small?: boolean
+  completedCoursesIds: string[]
 }> = ({
   children,
   resource,
@@ -30,8 +32,13 @@ const SearchHitResourceCard: React.FC<{
   className = '',
   describe = true,
   small = false,
+  completedCoursesIds,
   ...props
 }) => {
+  const isCourseCompleted =
+    !isEmpty(completedCoursesIds) &&
+    resource.id &&
+    completedCoursesIds?.some((courseId: string) => courseId === resource.id)
   const {fontSize, ref} = useFitText()
   if (isEmpty(resource)) return null
   const defaultClassName =
@@ -63,9 +70,14 @@ const SearchHitResourceCard: React.FC<{
             {resource.name && (
               <p
                 aria-hidden
-                className="uppercase font-medium sm:text-[0.65rem] text-[0.55rem] pb-1 text-gray-700 dark:text-indigo-100 opacity-60"
+                className="uppercase font-medium sm:text-[0.65rem] text-[0.55rem] pb-1 text-gray-700 dark:text-indigo-100 flex items-center"
               >
-                {resource.name}
+                {isCourseCompleted && (
+                  <span title="Course completed" className=" text-green-500">
+                    <CheckIcon />
+                  </span>
+                )}
+                <span className="opacity-60">{resource.name}</span>
               </p>
             )}
             {/* <Textfit

--- a/src/components/search/components/hit/index.tsx
+++ b/src/components/search/components/hit/index.tsx
@@ -3,9 +3,13 @@ import {SearchHitResourceCard} from 'components/card/search-hit-resource-card'
 
 type HitComponentProps = {
   hit: any
+  completedCoursesIds: string[]
 }
 
-const HitComponent: FunctionComponent<HitComponentProps> = ({hit}) => {
+const HitComponent: FunctionComponent<HitComponentProps> = ({
+  hit,
+  completedCoursesIds,
+}) => {
   const {image, type, instructor_url, instructor_name, instructor} = hit
 
   const hasImage = image !== 'https://d2eip9sf3oo6c2.cloudfront.net/logo.svg'
@@ -36,6 +40,7 @@ const HitComponent: FunctionComponent<HitComponentProps> = ({hit}) => {
             : null,
         },
       }}
+      completedCoursesIds={completedCoursesIds}
     />
   )
 }

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import {useQuery} from '@tanstack/react-query'
 import Grid from 'components/grid'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
@@ -9,18 +10,24 @@ import cx from 'classnames'
 import {NextSeo} from 'next-seo'
 import {CARD_TYPES} from 'components/search/curated/curated-essential'
 import {useRouter} from 'next/router'
+import {useViewer} from 'context/viewer-context'
+import {loadUserCompletedCourses} from 'lib/users'
+
+const useUserCompletedCourses = (viewerId: number) => {
+  return useQuery(['completeCourses'], async () => {
+    if (viewerId) {
+      const {completeCourses} = await loadUserCompletedCourses()
+      return completeCourses
+    }
+  })
+}
 
 type CuratedTopicProps = {
   topicData: any
   topic: any
-  completedCoursesIds: any
 }
 
-const CuratedTopic: React.FC<CuratedTopicProps> = ({
-  topic,
-  topicData,
-  completedCoursesIds,
-}) => {
+const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
   const {title, description, image, ogImage, sections, levels, jumbotron} =
     topicData
   const location = `${topic.name} landing`
@@ -29,6 +36,12 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({
     topic.label
   } Tutorials for ${new Date().getFullYear()}`
   const router = useRouter()
+  const {viewer} = useViewer()
+  const viewerId = viewer?.id
+  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const completedCoursesIds =
+    !isEmpty(completeCourseData) &&
+    completeCourseData.map((course: any) => course.collection.id)
 
   return (
     <>

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import {useQuery} from '@tanstack/react-query'
 import Grid from 'components/grid'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
@@ -10,24 +9,18 @@ import cx from 'classnames'
 import {NextSeo} from 'next-seo'
 import {CARD_TYPES} from 'components/search/curated/curated-essential'
 import {useRouter} from 'next/router'
-import {useViewer} from 'context/viewer-context'
-import {loadUserCompletedCourses} from 'lib/users'
-
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
-}
 
 type CuratedTopicProps = {
   topicData: any
   topic: any
+  completedCoursesIds: any
 }
 
-const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
+const CuratedTopic: React.FC<CuratedTopicProps> = ({
+  topic,
+  topicData,
+  completedCoursesIds,
+}) => {
   const {title, description, image, ogImage, sections, levels, jumbotron} =
     topicData
   const location = `${topic.name} landing`
@@ -36,12 +29,6 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
     topic.label
   } Tutorials for ${new Date().getFullYear()}`
   const router = useRouter()
-  const {viewer} = useViewer()
-  const viewerId = viewer?.id
-  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
-  const completedCoursesIds =
-    !isEmpty(completeCourseData) &&
-    completeCourseData.map((course: any) => course.collection.id)
 
   return (
     <>

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -131,9 +131,6 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                       </h2>
                       <h3 className="opacity-80">{section.subTitle}</h3>
                     </div>
-                    <h1 className="text-6xl text-red-500 border border-red-500 p-3 my-6">
-                      awfafdfd
-                    </h1>
                     <div className="grid xl:gap-5 gap-3">
                       {section.resources.map((resource: any) => {
                         return (

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -105,7 +105,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                       'sm:pt-24': i === 1,
                       'sm:pt-48': i === 0,
                     })}
-                    key={section.id}
+                    key={section.title}
                   >
                     <div className="flex flex-col w-full pb-6">
                       <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
@@ -134,7 +134,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
           {!isEmpty(sections) &&
             sections.map((section: any) => {
               return (
-                <section className="pb-16" key={section.id}>
+                <section className="pb-16" key={section.title}>
                   {!section.image && !section.description ? (
                     // simple section
                     <div className="flex w-full pb-6 items-center justify-between">
@@ -176,7 +176,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           return (
                             <HorizontalResourceCard
                               className="col-span-2"
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
@@ -185,13 +185,13 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           return i === 0 ? (
                             <HorizontalResourceCard
                               className="col-span-2"
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
                           ) : (
                             <VerticalResourceCard
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
@@ -200,13 +200,13 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           return i === 0 || i === 1 ? (
                             <HorizontalResourceCard
                               className="col-span-2"
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
                           ) : (
                             <VerticalResourceCard
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
@@ -215,13 +215,13 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           return i === 0 ? (
                             <HorizontalResourceCard
                               className="col-span-2"
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
                           ) : (
                             <VerticalResourceCard
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />
@@ -229,7 +229,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                         default:
                           return (
                             <VerticalResourceCard
-                              key={resource.id}
+                              key={resource.title}
                               resource={resource}
                               location={location}
                             />

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import {useQuery} from '@tanstack/react-query'
 import Grid from 'components/grid'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
@@ -9,6 +10,17 @@ import cx from 'classnames'
 import {NextSeo} from 'next-seo'
 import {CARD_TYPES} from 'components/search/curated/curated-essential'
 import {useRouter} from 'next/router'
+import {useViewer} from 'context/viewer-context'
+import {loadUserCompletedCourses} from 'lib/users'
+
+const useUserCompletedCourses = (viewerId: number) => {
+  return useQuery(['completeCourses'], async () => {
+    if (viewerId) {
+      const {completeCourses} = await loadUserCompletedCourses()
+      return completeCourses
+    }
+  })
+}
 
 type CuratedTopicProps = {
   topicData: any
@@ -24,6 +36,12 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
     topic.label
   } Tutorials for ${new Date().getFullYear()}`
   const router = useRouter()
+  const {viewer} = useViewer()
+  const viewerId = viewer?.id
+  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const completedCoursesIds =
+    !isEmpty(completeCourseData) &&
+    completeCourseData.map((course: any) => course.collection.id)
 
   return (
     <>
@@ -113,6 +131,9 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                       </h2>
                       <h3 className="opacity-80">{section.subTitle}</h3>
                     </div>
+                    <h1 className="text-6xl text-red-500 border border-red-500 p-3 my-6">
+                      awfafdfd
+                    </h1>
                     <div className="grid xl:gap-5 gap-3">
                       {section.resources.map((resource: any) => {
                         return (
@@ -120,6 +141,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                             key={resource.id}
                             resource={resource}
                             location={location}
+                            completedCoursesIds={completedCoursesIds}
                           />
                         )
                       })}
@@ -179,6 +201,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           )
                         case 3:
@@ -188,12 +211,14 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           ) : (
                             <VerticalResourceCard
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           )
                         case 6:
@@ -203,12 +228,14 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           ) : (
                             <VerticalResourceCard
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           )
                         case 7:
@@ -218,12 +245,14 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           ) : (
                             <VerticalResourceCard
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           )
                         default:
@@ -232,6 +261,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                               key={resource.title}
                               resource={resource}
                               location={location}
+                              completedCoursesIds={completedCoursesIds}
                             />
                           )
                       }

--- a/src/components/search/hits.tsx
+++ b/src/components/search/hits.tsx
@@ -1,18 +1,45 @@
 import React, {FunctionComponent} from 'react'
+import {isEmpty} from 'lodash'
+import {useQuery} from '@tanstack/react-query'
 import {connectHits} from 'react-instantsearch-dom'
 import HitComponent from './components/hit'
+import {useViewer} from 'context/viewer-context'
+import {loadUserCompletedCourses} from 'lib/users'
+
+const useUserCompletedCourses = (viewerId: number) => {
+  return useQuery(['completeCourses'], async () => {
+    if (viewerId) {
+      const {completeCourses} = await loadUserCompletedCourses()
+      return completeCourses
+    }
+  })
+}
 
 type CustomHitsProps = {
   hits: any[]
 }
 
-const CustomHits: FunctionComponent<CustomHitsProps> = ({hits}) => (
-  <div className="grid grid-col-1 sm:grid-cols-2 lg:grid-cols-3 auto-rows-max gap-3 p-3">
-    {hits.map((hit) => (
-      <HitComponent key={hit.objectID} hit={hit} />
-    ))}
-  </div>
-)
+const CustomHits: FunctionComponent<CustomHitsProps> = ({hits}) => {
+  const {viewer} = useViewer()
+  const viewerId = viewer?.id
+  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const completedCoursesIds =
+    !isEmpty(completeCourseData) &&
+    completeCourseData.map((course: any) => course.collection.id)
+  return (
+    <div className="grid grid-col-1 sm:grid-cols-2 lg:grid-cols-3 auto-rows-max gap-3 p-3">
+      {hits.map((hit) => {
+        return (
+          <HitComponent
+            key={hit.objectID}
+            hit={hit}
+            completedCoursesIds={completedCoursesIds}
+          />
+        )
+      })}
+    </div>
+  )
+}
 
 const Hits = connectHits(CustomHits)
 

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -291,9 +291,11 @@ const Search: FunctionComponent<SearchProps> = ({
                     Search Results
                   </h2>
                   <Hits />
-                  <div className="pb-16 pt-10 flex-grow bg-gradient-to-t dark:from-gray-1000 dark:to-transparent from-gray-100 to-transparent">
-                    <Pagination />
-                  </div>
+                  {mounted && (
+                    <div className="pb-16 pt-10 flex-grow bg-gradient-to-t dark:from-gray-1000 dark:to-transparent from-gray-100 to-transparent">
+                      <Pagination />
+                    </div>
+                  )}
                 </main>
               </div>
             </div>

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -14,9 +14,6 @@ import {
 } from 'react-instantsearch-dom'
 import {get, isEmpty} from 'lodash'
 import {useToggle} from 'react-use'
-import {useQuery} from '@tanstack/react-query'
-import {useViewer} from 'context/viewer-context'
-import {loadUserCompletedCourses} from 'lib/users'
 import config from 'lib/config'
 import InstructorsIndex from 'components/search/instructors/index'
 import NoSearchResults from 'components/search/components/no-search-results'
@@ -42,15 +39,6 @@ type SearchProps = {
   loading?: boolean
 }
 
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
-}
-
 const Search: FunctionComponent<SearchProps> = ({
   children = [],
   searchClient,
@@ -62,12 +50,7 @@ const Search: FunctionComponent<SearchProps> = ({
   ...rest
 }) => {
   const [isFilterShown, setShowFilter] = useToggle(false)
-  const {viewer} = useViewer()
-  const viewerId = viewer?.id
-  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
-  const completedCoursesIds =
-    !isEmpty(completeCourseData) &&
-    completeCourseData.map((course: any) => course.collection.id)
+
   const noInstructorsSelected = (searchState: any) => {
     return get(searchState, 'refinementList.instructor_name', []).length === 0
   }
@@ -291,7 +274,6 @@ const Search: FunctionComponent<SearchProps> = ({
                           <NewCuratedTopicPage
                             topicData={topicData}
                             topic={topic}
-                            completedCoursesIds={completedCoursesIds}
                           />
                         )}
                       </>

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,4 +1,5 @@
 import React, {FunctionComponent} from 'react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import Head from 'next/head'
 import Hits from './hits'
 import Stats from './stats'
@@ -38,6 +39,8 @@ type SearchProps = {
   topicData?: any
   loading?: boolean
 }
+
+const queryClient = new QueryClient()
 
 const Search: FunctionComponent<SearchProps> = ({
   children = [],
@@ -290,7 +293,9 @@ const Search: FunctionComponent<SearchProps> = ({
                   <h2 className="sm:px-5 px-3 mt-4 lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
                     Search Results
                   </h2>
-                  <Hits />
+                  <QueryClientProvider client={queryClient}>
+                    <Hits />
+                  </QueryClientProvider>
                   {mounted && (
                     <div className="pb-16 pt-10 flex-grow bg-gradient-to-t dark:from-gray-1000 dark:to-transparent from-gray-100 to-transparent">
                       <Pagination />

--- a/src/hooks/use-load-topic-data.ts
+++ b/src/hooks/use-load-topic-data.ts
@@ -59,6 +59,7 @@ export const topicQuery = groq`*[_type == 'resource' && type == 'landing-page' &
         subTitle,
         resources[]->{
           'id': _id,
+          externalId,
           title,
           'name': type,
           path,
@@ -80,6 +81,7 @@ export const topicQuery = groq`*[_type == 'resource' && type == 'landing-page' &
       resources[]{
         _type == 'reference' => @->{
           'id': _id,
+          externalId,
           title,
           'name': type,
           'description': summary,


### PR DESCRIPTION
this adds ✅ label to completed courses on the Search page:

- [x] put label on curated part of the search page
- [x] put label on completed course cards in search results

<details>
  <summary>Curated part of the Search Page:</summary>
  <img width="1000" src="https://user-images.githubusercontent.com/1519448/211910217-eff749b4-a470-4be2-842e-3890d8a86914.jpg">
</details>
<details>
  <summary>Search results:</summary>
  <img width="1000" src="https://user-images.githubusercontent.com/1519448/211910153-da6f5b7b-7fb1-4da6-9ecd-c121a2475fc6.jpg">
</details>

Technically, it works.
What I'm not happy with is that I use the same `useQuery` call twice on the same page (`src/components/search/index.tsx`) in two child components: `<NewCuratedTopicPage />` and `<Hits />`. Moreover, I was forced to wrap `<Hits />` with additional `<QueryClientProvider>`, otherwise I get the error described below. The `useQuery` call in `<NewCuratedTopicPage />` works smooth though. I've tried to move `useQuery` call on parent level (`src/components/search/index.tsx`, `<Search />`) and just pass the call result as props to child components, but I've got the error described here: https://eggheadio.slack.com/archives/G01CAT0P9TL/p1673398982014119

Would be happy if someone could help me to understand what I'm missing here 🥸