### PR TITLE
fix: correctly display gift membership message

### DIFF
--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -7,6 +7,8 @@ export async function loadAccount(slug: string, token: string) {
         slug
         stripe_customer_id
         subscriptions {
+          type
+          current_period_end
           stripe_subscription_id
         }
       }

--- a/src/pages/gifts/claim/[guid].tsx
+++ b/src/pages/gifts/claim/[guid].tsx
@@ -95,10 +95,8 @@ const GiftClaim: React.FC<GiftClaimProps> = ({error, gift}) => {
                 <em>
                   <b>on top of your existing membership</b>
                 </em>
-                . They stack. You can claim 10 gift memberships and have PRO
-                access for 10 years. When the gift expires, your existing
-                membership will resume. You will not lose any membership
-                time/money.
+                . When the gift expires, your existing membership will resume.
+                You will not lose any membership time/money.
               </p>
             ) : (
               <p>

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -10,6 +10,7 @@ import UserLayout from './components/user-layout'
 import PricingWidget from 'components/pricing/pricing-widget'
 import Invoices from 'components/invoices'
 import Spinner from 'components/spinner'
+import {format} from 'date-fns'
 
 type ViewerAccount = {
   stripe_customer_id: string
@@ -34,6 +35,9 @@ const Account = () => {
   const {slug} = getAccountWithSubscription(accounts)
   const [accountIsLoading, setAccountIsLoading] = React.useState<boolean>(true)
 
+  const isGiftMembership = account?.subscriptions[0]?.type === 'gift'
+  const giftExpiration = account?.subscriptions[0]?.current_period_end
+
   const loadAccountForSlug = async (slug: string) => {
     if (slug) {
       const account: any = await loadAccount(slug, authToken)
@@ -51,6 +55,16 @@ const Account = () => {
       {accountIsLoading ? (
         <div className="relative flex justify-center">
           <Spinner className="w-6 h-6 text-gray-600" />
+        </div>
+      ) : isGiftMembership ? (
+        <div className="h-40 sm:h-60 flex flex-col justify-center">
+          <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
+            You have claimed a gift membership.
+          </h2>
+          <p className="w-fit mx-auto">
+            Your membership expires on:{' '}
+            <strong>{format(new Date(giftExpiration), 'yyyy/MM/dd')}</strong>.
+          </p>
         </div>
       ) : account?.stripe_customer_id ? (
         <>

--- a/src/pages/user/subscription.tsx
+++ b/src/pages/user/subscription.tsx
@@ -59,7 +59,7 @@ const Account = () => {
       ) : isGiftMembership ? (
         <div className="h-40 sm:h-60 flex flex-col justify-center">
           <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
-            You have claimed a gift membership.
+            You have an egghead membership.
           </h2>
           <p className="w-fit mx-auto">
             Your membership expires on:{' '}


### PR DESCRIPTION
This fixes [EGG-134](https://linear.app/skillrecordings/issue/EGG-134/re-my-early-subscription-is-gone) where gift memberships are showing 'No Subscription Found' because we are only checking if `stripe_subscription_id` exists. Gift memberships have a null `stripe_subscrition_id`

Currently very simple messaging, any suggestions there? 
![image](https://user-images.githubusercontent.com/6188161/212435560-c955bde6-8200-49b4-b856-0b23354b493a.png)


![gift](https://media3.giphy.com/media/67T9R8UDKgvHOKtseK/giphy.gif?cid=1927fc1bvm0fz4md70oppu7izkd2gf7mofm0mbk9xj2u5086&rid=giphy.gif&ct=g)