### PR TITLE
fix egg-135: update messaging for canceled accounts

### DIFF
--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import {track} from 'utils/analytics'
 import {useViewer} from 'context/viewer-context'
 import {get} from 'lodash'
+import {format} from 'date-fns'
 import useSubscriptionDetails, {recur} from 'hooks/use-subscription-data'
 import PricingWidget from '../../../pricing/pricing-widget'
 
@@ -38,47 +39,60 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         minimumFractionDigits: 0,
       }).format(subscriptionUnitAmount / 100)
 
+    const subscriptionEndDate = get(
+      subscriptionData,
+      'subscriptionData.subscription.current_period_end',
+    )
+
+    console.log(subscriptionData)
+
     return !loading && subscriptionData ? (
       <div className="w-full">
         {subscriptionName ? (
-          <>
-            <h3 className="mb-2 text-lg font-medium">
+          <div className="md:w-[75ch] mx-auto">
+            {subscriptionData?.subscription?.cancel_at_period_end && (
+              <div className="my-8 p-4 bg-red-100 rounded text-gray-900 space-y-2">
+                <p>
+                  Your membership is currently cancelled and it will not
+                  auto-renew. You'll have access until the end of your current
+                  billing period (
+                  <strong>
+                    {format(
+                      new Date(
+                        subscriptionData?.subscription?.current_period_end,
+                      ),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  ). You can renew at any time.
+                </p>
+                <p></p>
+                <p></p>
+              </div>
+            )}
+            <h3 className="mb-2 text-lg font-medium text-center">
               ⭐️ You're an <strong>egghead Member!</strong>
             </h3>
-            <p className="text-accents-5">
+            <p className="text-accents-5 text-center">
               You can update your plan and payment information below via Stripe.
             </p>
             <div className="mt-8 mb-4 font-semibold">
               {!subscriptionData?.portalUrl ? (
                 <div className="h-12 mb-6">loading</div>
-              ) : subscriptionPrice ? (
-                <div className="flex space-x-2">
-                  <div>
-                    You are currently paying{' '}
-                    {`${subscriptionPrice}/${recur(subscriptionData.price)}`}{' '}
-                    for your membership
-                  </div>
-                  {subscriptionData?.subscription?.cancel_at_period_end && (
-                    <div className="flex items-center justify-center px-2 py-1 text-xs bg-gray-100 rounded text-gray-1000 mt-2">
-                      cancelled
-                    </div>
-                  )}
-                </div>
               ) : (
-                <Link href="/pricing">
-                  <a
-                    onClick={() => {
-                      track(`clicked pricing`, {
-                        location: 'accounts',
-                      })
-                    }}
-                  >
-                    Join today!
-                  </a>
-                </Link>
+                subscriptionPrice &&
+                !subscriptionData?.subscription?.cancel_at_period_end && (
+                  <div className="flex space-x-2 justify-center">
+                    <div>
+                      You are currently paying{' '}
+                      {`${subscriptionPrice}/${recur(subscriptionData.price)}`}{' '}
+                      for your membership
+                    </div>
+                  </div>
+                )
               )}
             </div>
-          </>
+          </div>
         ) : (
           <>
             {(viewer.is_pro || viewer.is_instructor) && (
@@ -98,26 +112,15 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         {(subscriptionData?.subscription?.cancel_at_period_end ||
           subscriptionData?.portalUrl) && (
           <div className="bg-primary-2 text-accents-3 rounded-b-md mt-6">
-            <div className="flex flex-col items-start justify-between sm:items-center">
-              {subscriptionData?.subscription?.cancel_at_period_end && (
-                <p className="pb-4 sm:pb-0">
-                  Your account is currently cancelled. You'll have access until
-                  the end of your current billing period. You can also renew at
-                  any time.
-                </p>
-              )}
+            <div className="flex flex-col justify-between items-center">
               {subscriptionData.subscription && subscriptionData?.portalUrl ? (
                 <>
-                  <p className="mt-1">
-                    You can still update your payment information below via
-                    Stripe.
-                  </p>
                   <Link href={subscriptionData.portalUrl}>
                     <a
                       onClick={() => {
                         track(`clicked manage membership`)
                       }}
-                      className="w-full px-5 py-3 mt-4 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md hover:bg-blue-700 active:bg-blue-800 hover:scale-105 hover:shadow-xl"
+                      className="w-2/3 px-5 py-3 mt-4 font-semibold text-center text-white transition-all duration-150 ease-in-out bg-blue-600 rounded-md hover:bg-blue-700 active:bg-blue-800 hover:scale-105 hover:shadow-xl"
                     >
                       Manage Your Membership
                     </a>


### PR DESCRIPTION
Our messaging around active yet cancelled subscriptions is not super clear. This PR updates that messaging and cleans up `SubscriptionDetails` component. 

I'm using `current_period_end` on the stripe subscription to let the user know when they lose access but the date that comes back is set for 1970 🤔 not sure if that's just a testing data thing... ?

![canceled state desktop](https://user-images.githubusercontent.com/6188161/213255505-2c8c121f-7deb-46c9-8730-329e4fdd23d5.png)
![canceled state mobile](https://user-images.githubusercontent.com/6188161/213255524-5b9d8869-a5c1-4124-83ce-edea8a73a35b.png)
![active subscription](https://user-images.githubusercontent.com/6188161/213255533-03eb9a90-566c-4bd7-89b6-f4cc0de0098f.png)


![canceled](https://media1.giphy.com/media/ZCTCZiOwJGDaTAF21f/giphy.gif?cid=1927fc1b8hdr35wyr83fm5hko6ndny8gsanu6b6j7yqp8e2m&rid=giphy.gif&ct=g)