### PR TITLE
feat: remove the old holiday 2021 holiday section

### DIFF
--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -198,9 +198,6 @@ const Home: React.FC<any> = ({data, jumbotron, location}) => {
                 </section>
               )
             })}
-          <div className="mb-16 bg-white bg-opacity-100 rounded-lg md:container dark:bg-gray-800 dark:bg-opacity-60">
-            <HolidayReleaseJumbotron />
-          </div>
           <Search />
         </main>
       </div>


### PR DESCRIPTION
I'm currently thinking about the homepage and noticed the old holiday image was still being displayed.

## Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/518406/213311448-4b7251fa-2177-45b1-a043-b8a727807e98.png">

## After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/518406/213311309-cc589ccc-e391-45fd-9636-e0d908ff7157.png">

## Hilarious GIF
![skeleton santa](https://media0.giphy.com/media/xULW8LLgSuKGS2Q22Y/giphy.gif?cid=01d288b0k0yxwofhhe0rerzci94tf2yyjfzj8l9zz1wq54am&rid=giphy.gif&ct=g)
