### PR TITLE
fixes EGG-142: update membership terminology for customer facing views

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -160,6 +160,11 @@ const searchRoutes = [
 
 const legacyRoutes = [
   {
+    source: `/user/subscription`,
+    destination: `/user/membership`,
+    permanent: true,
+  },
+  {
     source: `/user`,
     destination: `/user/membership`,
     permanent: true,

--- a/next.config.js
+++ b/next.config.js
@@ -161,7 +161,7 @@ const searchRoutes = [
 const legacyRoutes = [
   {
     source: `/user`,
-    destination: `/user/subscription`,
+    destination: `/user/membership`,
     permanent: true,
   },
   {

--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -104,7 +104,7 @@ const Header: FunctionComponent = () => {
 
   const User = () => {
     return (
-      <Link href="/user/subscription">
+      <Link href="/user/membership">
         <a
           onClick={() =>
             track('clicked account', {

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-import {track} from 'utils/analytics'
+import analytics, {track} from 'utils/analytics'
 import {useViewer} from 'context/viewer-context'
 import {get} from 'lodash'
 import {format} from 'date-fns'
@@ -38,13 +38,6 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         currency: currency,
         minimumFractionDigits: 0,
       }).format(subscriptionUnitAmount / 100)
-
-    const subscriptionEndDate = get(
-      subscriptionData,
-      'subscriptionData.subscription.current_period_end',
-    )
-
-    console.log(subscriptionData)
 
     return !loading && subscriptionData ? (
       <div className="w-full">

--- a/src/components/pricing/pricing-widget/index.tsx
+++ b/src/components/pricing/pricing-widget/index.tsx
@@ -79,7 +79,7 @@ const PricingWidget: FunctionComponent<{}> = () => {
         .then(({data}) => data)
 
       if (hasProAccess) {
-        const message = `You already have pro access with this account (${viewer?.email}). Please contact support@egghead.io if you need help with your subscription.`
+        const message = `You already have pro access with this account (${viewer?.email}). Please contact support@egghead.io if you need help with your membership.`
 
         toast.error(message, {
           duration: 6000,

--- a/src/components/team/billing-section.tsx
+++ b/src/components/team/billing-section.tsx
@@ -44,7 +44,7 @@ const BillingSection = ({
 
   switch (recurrence) {
     case 'year': {
-      subscriptionName = 'Annual egghead Team Subscription'
+      subscriptionName = 'Annual egghead Team Membership'
       subscriptionDescription = 'Yearly Pro Membership'
       break
     }
@@ -54,7 +54,7 @@ const BillingSection = ({
       break
     }
     case 'month': {
-      subscriptionName = 'Monthly egghead Team Subscription'
+      subscriptionName = 'Monthly egghead Team Membership'
       subscriptionDescription = 'Monthly Pro Membership'
       break
     }

--- a/src/components/users/subscription-details.tsx
+++ b/src/components/users/subscription-details.tsx
@@ -91,7 +91,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                   ) : (
                     <div className="px-5 py-4">
                       <h3 className="mb-1 text-2xl font-medium">
-                        No paid subscription found.
+                        No membership found.
                       </h3>
                       {(viewer.is_pro || viewer.is_instructor) && (
                         <p>

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -12,7 +12,7 @@ export default ({children}) => (
 
 #### What payment methods are accepted?
 
-Currently, we only accept payment via credit card for individual subscriptions and teams consisting of less than 30 members.
+Currently, we only accept payment via credit card for individual memberships and teams consisting of less than 30 members.
 
 We do not accept PayPal.
 
@@ -20,9 +20,9 @@ We do not accept PayPal.
 
 If you are purchasing for a team of 30+ members, please contact us at support@egghead.io for more information on invoicing.
 
-#### Do you have payment plans available for an annual subscription?
+#### Do you have payment plans available for an annual memberships?
 
-We don’t offer payment plans. If you’re able, you can start out with a monthly or quarterly plan and then upgrade to an annual subscription in the future.
+We don’t offer payment plans. If you’re able, you can start out with a monthly or quarterly plan and then upgrade to an annual membership in the future.
 
 #### Where can I find my invoices?
 
@@ -32,9 +32,9 @@ From there, you can also add any required information to the "Prepared for" sect
 
 #### Renewal cost from year-to-year
 
-Your subscription price will be locked in at the time you purchase, and will continue to renew at that price each billing cycle unless/until you cancel it.
+Your membership price will be locked in at the time you purchase, and will continue to renew at that price each billing cycle unless/until you cancel it.
 
-#### Can I get a refund for a new subscription or a recent renewal charge?
+#### Can I get a refund for a new membership or a recent renewal charge?
 
 Please contact **[support@egghead.io](mailto:support@egghead.io)** to request a refund.
 
@@ -44,15 +44,15 @@ If you are issued a refund, it will be processed, and a credit will automaticall
 
 If you haven’t received your refund after 10 business days, first check your bank account again. Then contact your credit card company, it may take some time before your refund is officially posted. Next, contact your bank. There is often some processing time before a refund is posted. If you’ve done all of this and you still have not received your refund yet, please contact us at **[support@egghead.io](mailto:support@egghead.io)**.
 
-## Subscription
+## Membership
 
-#### Will my subscription automatically renew?
+#### Will my membership automatically renew?
 
-Yes, all subscriptions will automatically renew at the end of each billing period unless they are canceled before the renewal date.
+Yes, all memberships will automatically renew at the end of each billing period unless they are canceled before the renewal date.
 
-#### Can I cancel my subscription?
+#### Can I cancel my membership?
 
-Yes, you can cancel your subscription at any time before your next renewal date to prevent it from automatically renewing. When you cancel, your subscription will remain active until your renewal date but will not renew at that time.
+Yes, you can cancel your membership at any time before your next renewal date to prevent it from automatically renewing. When you cancel, your membership will remain active until your renewal date but will not renew at that time.
 
 If you’d like to cancel, you can do that from your account profile by following the steps below:
 
@@ -67,13 +67,13 @@ If we offer parity pricing in your area, it will automatically show up on the pr
 
 Yes, the specific terms and conditions are listed with the parity discount offer that is displayed on the pricing page.
 
-#### Do you offer gift subscriptions?
+#### Do you offer gift memberships?
 
 No.
 
 #### Do you offer any discounts?
 
-We provide parity pricing discounts for some regions, but we don’t offer any other form of discount. However, we do have sale events periodically throughout the year where you can purchase a subscription at a discounted price.
+We provide parity pricing discounts for some regions, but we don’t offer any other form of discount. However, we do have sale events periodically throughout the year where you can purchase a membership at a discounted price.
 
 #### Are there free courses available?
 

--- a/src/pages/invoices/[stripeTransactionId].tsx
+++ b/src/pages/invoices/[stripeTransactionId].tsx
@@ -44,12 +44,12 @@ const InvoicePage: React.FunctionComponent<any> = ({transactionId}) => {
   return (
     <LoginRequired>
       <main className="container py-5 mb-16 max-w-screen-md">
-        <Link href="/user/subscription">
+        <Link href="/user/membership">
           <a className="print:hidden">
             <div className="flex ">
               {' '}
               <ArrowNarrowLeftIcon className="flex-shrink-0 mr-2 h-6 w-6" />{' '}
-              Back to Profile
+              Back to Membership page
             </div>
           </a>
         </Link>

--- a/src/pages/user/components/user-layout.tsx
+++ b/src/pages/user/components/user-layout.tsx
@@ -12,8 +12,8 @@ import LoginRequired from 'components/login-required'
 
 const userPagesMap = [
   {
-    path: '/user/subscription',
-    name: 'Subscription',
+    path: '/user/membership',
+    name: 'Membership',
     icon: CreditCardIcon,
   },
   {

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -79,7 +79,7 @@ const Account = () => {
       ) : (
         <>
           <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
-            No Subscription Found
+            No Membership Found
           </h2>
           <p className="w-fit mx-auto mb-12">
             If this is incorrect, please reach out to{' '}

--- a/src/server/get-middleware-response.ts
+++ b/src/server/get-middleware-response.ts
@@ -42,7 +42,7 @@ export async function getMiddlewareResponse(req: NextRequest) {
   if (req.nextUrl.pathname.startsWith(PRICING_PAGE_PATH)) {
     switch (true) {
       case isLoggedInMember:
-        response = rewriteToPath('/user/subscription', req)
+        response = rewriteToPath('/user/membership', req)
         break
       case isMember:
         response = rewriteToPath('/login', req)


### PR DESCRIPTION
This changes any 'subscription' language to 'membership' for customer facing views. 

- Changes /user/subscription to /user/membership and updates those links throughout
- Changes the use of subscription in copy to membership


![members only](https://media2.giphy.com/media/ehyFAxKmkEhxQn3Gv7/giphy.gif?cid=1927fc1bv1snwusm37620dtwsqtk4sv7v0dcd1f1cli18hfs&rid=giphy.gif&ct=g)