### PR TITLE
fixes egg-159: add course type to collection query

### DIFF
--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -196,6 +196,32 @@ export async function loadUserCompletedCourses(token?: string): Promise<any> {
             path
             id
           }
+          ... on Course {
+            title
+            lessons {
+              title
+              slug
+              path
+            }
+            image: image_thumb_url
+            type
+            path
+            progress {
+              lesson_count
+              completed_lesson_count
+              is_completed
+              completed_at
+              completed_lessons {
+                title
+                slug
+                path
+              }
+            }
+            instructor {
+              full_name
+              avatar_64_url
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
We weren't pulling in all the data that we should with `courseCompletions` query. 

This adds the course type which affects any course that was migrated over from course to playlist. This makes me wonder if there are other instances where this migration has affected courses. For instance, the Web Security Essentials course last review was 2 years ago even though in slack we have a review logged at Nov 2nd, 2022.

![activity shows correctly](https://user-images.githubusercontent.com/6188161/214634613-99219f39-c36a-47dc-b106-137489389a72.jpg)


![something is missing](https://media.giphy.com/media/3ogwG9DMANbyPIz0fm/giphy.gif)