### PR TITLE
Fixes EGG-40: allow team plan to cancel

### DIFF
--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -50,6 +50,85 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
     return !loading && subscriptionData ? (
       <div className="w-full">
         {subscriptionName ? (
+          // subscriptionName === true
+          <div className="w-full">
+            <label htmlFor="">subscriptionName === true</label>
+            {isTeamAccountOwner ? (
+              <h3 className="text-lg font-medium text-center">
+                ⭐️ You've got a team membership! ⭐️
+              </h3>
+            ) : (
+              <h3 className="text-lg font-medium text-center">
+                ⭐️ You're an <strong>egghead Member!</strong>
+              </h3>
+            )}
+            {isTeamAccountOwner && wasCanceled && (
+              <div>
+                <label htmlFor="">isTeamAccountOwner && wasCanceled</label>
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong> team
+                  membership for <strong>{number_of_members} seats</strong> is
+                  currently cancelled and it will not auto-renew.
+                </p>
+                <p>
+                  Your team will still have access until the end of your current
+                  billing period (
+                  <strong>
+                    {format(
+                      new Date(
+                        subscriptionData?.subscription?.current_period_end *
+                          1000,
+                      ),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  ). You can renew at any time.
+                </p>
+              </div>
+            )}
+            {isTeamAccountOwner && !wasCanceled && (
+              <div>
+                <label htmlFor="">isTeamAccountOwner && !wasCanceled</label>
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong> team
+                  membership for <strong>{number_of_members} seats</strong> will
+                  automatically renew for <strong>{subscriptionPrice}</strong>{' '}
+                  on{' '}
+                  <strong>
+                    {format(
+                      new Date(account.subscriptions[0].current_period_end),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  If you would like to cancel auto-renewal or change the number
+                  of seats for your team, you can use the Manage Your Membership
+                  Billing button below.
+                </p>
+              </div>
+            )}
+            {!isTeamAccountOwner && wasCanceled && (
+              <div>
+                <label htmlFor="">!isTeamAccountOwner && wasCanceled</label>
+              </div>
+            )}
+            {!isTeamAccountOwner && !wasCanceled && (
+              <div>
+                <label htmlFor="">!isTeamAccountOwner && !wasCanceled</label>
+              </div>
+            )}
+          </div>
+        ) : (
+          // subscriptionName === false
+          <div className="w-full">
+            <label htmlFor="">subscriptionName === false</label>
+          </div>
+        )}
+
+        <div className="mt-16">===========================</div>
+        {subscriptionName ? (
           <>
             {isTeamAccountOwner ? (
               <h3 className="text-lg font-medium text-center">
@@ -83,27 +162,52 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </div>
             ) : (
               <div className="w-full leading-relaxed mt-4">
-                <p>
-                  Your <strong>{interval}ly</strong> team subscription for{' '}
-                  <strong>{number_of_members} seats</strong> will automatically
-                  renew for{' '}
-                  <strong>{`${subscriptionPrice}/${recur(
-                    subscriptionData.price,
-                  )}`}</strong>{' '}
-                  on{' '}
-                  <strong>
-                    {format(
-                      new Date(account.subscriptions[0].current_period_end),
-                      'yyyy/MM/dd',
-                    )}
-                  </strong>
-                  .
-                </p>
-                <p>
-                  If you would like to cancel auto-renewal or change the number
-                  of seats for your team, you can use the Manage Your Membership
-                  Billing button below.
-                </p>
+                {wasCanceled ? (
+                  <>
+                    <p>
+                      Your membership is currently cancelled and it will not
+                      auto-renew.
+                    </p>
+                    <p>
+                      Your team will still have access until the end of your
+                      current billing period (
+                      <strong>
+                        {format(
+                          new Date(
+                            subscriptionData?.subscription?.current_period_end *
+                              1000,
+                          ),
+                          'yyyy/MM/dd',
+                        )}
+                      </strong>
+                      ). You can renew at any time.
+                    </p>
+                  </>
+                ) : (
+                  <div>
+                    <p>
+                      Your <strong>{interval}ly</strong> team subscription for{' '}
+                      <strong>{number_of_members} seats</strong> will
+                      automatically renew for{' '}
+                      <strong>{`${subscriptionPrice}/${recur(
+                        subscriptionData.price,
+                      )}`}</strong>{' '}
+                      on{' '}
+                      <strong>
+                        {format(
+                          new Date(account.subscriptions[0].current_period_end),
+                          'yyyy/MM/dd',
+                        )}
+                      </strong>
+                      .
+                    </p>
+                    <p>
+                      If you would like to cancel auto-renewal or change the
+                      number of seats for your team, you can use the Manage Your
+                      Membership Billing button below.
+                    </p>
+                  </div>
+                )}
               </div>
             )}
             {/* <p className="text-accents-5 text-center">

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -19,7 +19,11 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
     const {subscriptionData, loading} = useSubscriptionDetails({
       stripeCustomerId,
     })
-    const {isTeamAccountOwner} = useAccount()
+    const {isTeamAccountOwner, account} = useAccount()
+    const {number_of_members} = account
+    const {interval} = account?.subscriptions[0]
+    // console.log({account})
+    console.log({subscriptionData})
 
     const subscriptionName = subscriptionData?.product?.name
     const subscriptionUnitAmount = get(
@@ -41,39 +45,68 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         minimumFractionDigits: 0,
       }).format(subscriptionUnitAmount / 100)
 
-    const currentPeriodEnd =
-      subscriptionData?.subscription?.cancel_at_period_end &&
-      subscriptionData?.subscription?.current_period_end * 1000
+    const wasCanceled = subscriptionData?.subscription?.cancel_at_period_end
 
     return !loading && subscriptionData ? (
       <div className="w-full">
         {subscriptionName ? (
-          <div className="md:w-[75ch] mx-auto">
-            {currentPeriodEnd && (
-              <div className="my-8 p-4 bg-red-100 rounded text-gray-900 space-y-2">
-                <p>
-                  Your membership is currently cancelled and it will not
-                  auto-renew. You'll have access until the end of your current
-                  billing period (
-                  <strong>
-                    {format(new Date(currentPeriodEnd), 'yyyy/MM/dd')}
-                  </strong>
-                  ). You can renew at any time.
-                </p>
-                <p></p>
-                <p></p>
-              </div>
-            )}
+          <>
             {isTeamAccountOwner ? (
-              <h3 className="mb-2 text-lg font-medium text-center">
+              <h3 className="text-lg font-medium text-center">
                 ⭐️ You've got a team membership! ⭐️
               </h3>
             ) : (
-              <h3 className="mb-2 text-lg font-medium text-center">
+              <h3 className="text-lg font-medium text-center">
                 ⭐️ You're an <strong>egghead Member!</strong>
               </h3>
             )}
-            <p className="text-accents-5 text-center">
+            {isTeamAccountOwner && wasCanceled ? (
+              <div className="w-full leading-relaxed mt-4">
+                <p>
+                  Your membership is currently cancelled and it will not
+                  auto-renew.
+                </p>
+                <p>
+                  Your team will still have access until the end of your current
+                  billing period (
+                  <strong>
+                    {format(
+                      new Date(
+                        subscriptionData?.subscription?.current_period_end *
+                          1000,
+                      ),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  ). You can renew at any time.
+                </p>
+              </div>
+            ) : (
+              <div className="w-full leading-relaxed mt-4">
+                <p>
+                  Your <strong>{interval}ly</strong> team subscription for{' '}
+                  <strong>{number_of_members} seats</strong> will automatically
+                  renew for{' '}
+                  <strong>{`${subscriptionPrice}/${recur(
+                    subscriptionData.price,
+                  )}`}</strong>{' '}
+                  on{' '}
+                  <strong>
+                    {format(
+                      new Date(account.subscriptions[0].current_period_end),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  If you would like to cancel auto-renewal or change the number
+                  of seats for your team, you can use the Manage Your Membership
+                  Billing button below.
+                </p>
+              </div>
+            )}
+            {/* <p className="text-accents-5 text-center">
               You can update your plan and payment information below via Stripe.
             </p>
             <div className="mt-8 mb-4 font-semibold">
@@ -91,8 +124,8 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                   </div>
                 )
               )}
-            </div>
-          </div>
+            </div> */}
+          </>
         ) : (
           <>
             {(viewer.is_pro || viewer.is_instructor) && (

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -21,7 +21,6 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
     })
     const {isTeamAccountOwner, account} = useAccount()
     const {number_of_members} = account
-    const {interval} = account?.subscriptions[0]
 
     const subscriptionName = subscriptionData?.product?.name
     const subscriptionUnitAmount = get(

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -22,8 +22,6 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
     const {isTeamAccountOwner, account} = useAccount()
     const {number_of_members} = account
     const {interval} = account?.subscriptions[0]
-    // console.log({account})
-    console.log({subscriptionData})
 
     const subscriptionName = subscriptionData?.product?.name
     const subscriptionUnitAmount = get(
@@ -50,9 +48,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
     return !loading && subscriptionData ? (
       <div className="w-full">
         {subscriptionName ? (
-          // subscriptionName === true
           <div className="w-full">
-            <label htmlFor="">subscriptionName === true</label>
             {isTeamAccountOwner ? (
               <h3 className="text-lg font-medium text-center">
                 ⭐️ You've got a team membership! ⭐️
@@ -63,16 +59,16 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </h3>
             )}
             {isTeamAccountOwner && wasCanceled && (
-              <div>
-                <label htmlFor="">isTeamAccountOwner && wasCanceled</label>
+              <div className="w-full leading-relaxed mt-4">
                 <p>
                   Your <strong>{recur(subscriptionData.price)}ly</strong> team
-                  membership for <strong>{number_of_members} seats</strong> is
+                  membership for <strong>{number_of_members} seats</strong>{' '}
+                  (from <strong>{account?.capacity}</strong> available) is
                   currently cancelled and it will not auto-renew.
                 </p>
                 <p>
                   Your team will still have access until the end of your current
-                  billing period (
+                  billing period -{' '}
                   <strong>
                     {format(
                       new Date(
@@ -82,16 +78,20 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                       'yyyy/MM/dd',
                     )}
                   </strong>
-                  ). You can renew at any time.
+                  .
+                </p>
+                <p>
+                  You can renew at any time using the Manage Your Membership
+                  Billing button below.
                 </p>
               </div>
             )}
             {isTeamAccountOwner && !wasCanceled && (
-              <div>
-                <label htmlFor="">isTeamAccountOwner && !wasCanceled</label>
+              <div className="w-full leading-relaxed mt-4">
                 <p>
                   Your <strong>{recur(subscriptionData.price)}ly</strong> team
-                  membership for <strong>{number_of_members} seats</strong> will
+                  membership for <strong>{number_of_members} seats</strong>{' '}
+                  (from <strong>{account?.capacity}</strong> available) will
                   automatically renew for <strong>{subscriptionPrice}</strong>{' '}
                   on{' '}
                   <strong>
@@ -110,44 +110,14 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </div>
             )}
             {!isTeamAccountOwner && wasCanceled && (
-              <div>
-                <label htmlFor="">!isTeamAccountOwner && wasCanceled</label>
-              </div>
-            )}
-            {!isTeamAccountOwner && !wasCanceled && (
-              <div>
-                <label htmlFor="">!isTeamAccountOwner && !wasCanceled</label>
-              </div>
-            )}
-          </div>
-        ) : (
-          // subscriptionName === false
-          <div className="w-full">
-            <label htmlFor="">subscriptionName === false</label>
-          </div>
-        )}
-
-        <div className="mt-16">===========================</div>
-        {subscriptionName ? (
-          <>
-            {isTeamAccountOwner ? (
-              <h3 className="text-lg font-medium text-center">
-                ⭐️ You've got a team membership! ⭐️
-              </h3>
-            ) : (
-              <h3 className="text-lg font-medium text-center">
-                ⭐️ You're an <strong>egghead Member!</strong>
-              </h3>
-            )}
-            {isTeamAccountOwner && wasCanceled ? (
               <div className="w-full leading-relaxed mt-4">
                 <p>
-                  Your membership is currently cancelled and it will not
-                  auto-renew.
+                  Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
+                  membership is currently cancelled and it will not auto-renew.
                 </p>
                 <p>
-                  Your team will still have access until the end of your current
-                  billing period (
+                  You will still have access until the end of your current
+                  billing period -{' '}
                   <strong>
                     {format(
                       new Date(
@@ -157,81 +127,37 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                       'yyyy/MM/dd',
                     )}
                   </strong>
-                  ). You can renew at any time.
+                  .
+                </p>
+                <p>
+                  You can renew at any time using the Manage Your Membership
+                  Billing button below.
                 </p>
               </div>
-            ) : (
+            )}
+            {!isTeamAccountOwner && !wasCanceled && (
               <div className="w-full leading-relaxed mt-4">
-                {wasCanceled ? (
-                  <>
-                    <p>
-                      Your membership is currently cancelled and it will not
-                      auto-renew.
-                    </p>
-                    <p>
-                      Your team will still have access until the end of your
-                      current billing period (
-                      <strong>
-                        {format(
-                          new Date(
-                            subscriptionData?.subscription?.current_period_end *
-                              1000,
-                          ),
-                          'yyyy/MM/dd',
-                        )}
-                      </strong>
-                      ). You can renew at any time.
-                    </p>
-                  </>
-                ) : (
-                  <div>
-                    <p>
-                      Your <strong>{interval}ly</strong> team subscription for{' '}
-                      <strong>{number_of_members} seats</strong> will
-                      automatically renew for{' '}
-                      <strong>{`${subscriptionPrice}/${recur(
-                        subscriptionData.price,
-                      )}`}</strong>{' '}
-                      on{' '}
-                      <strong>
-                        {format(
-                          new Date(account.subscriptions[0].current_period_end),
-                          'yyyy/MM/dd',
-                        )}
-                      </strong>
-                      .
-                    </p>
-                    <p>
-                      If you would like to cancel auto-renewal or change the
-                      number of seats for your team, you can use the Manage Your
-                      Membership Billing button below.
-                    </p>
-                  </div>
-                )}
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
+                  membership will automatically renew for{' '}
+                  <strong>{subscriptionPrice}</strong> on{' '}
+                  <strong>
+                    {format(
+                      new Date(account.subscriptions[0].current_period_end),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  If you would like to cancel auto-renewal you can use the
+                  Manage Your Membership Billing button below.
+                </p>
               </div>
             )}
-            {/* <p className="text-accents-5 text-center">
-              You can update your plan and payment information below via Stripe.
-            </p>
-            <div className="mt-8 mb-4 font-semibold">
-              {!subscriptionData?.portalUrl ? (
-                <div className="h-12 mb-6">loading</div>
-              ) : (
-                subscriptionPrice &&
-                !subscriptionData?.subscription?.cancel_at_period_end && (
-                  <div className="flex space-x-2 justify-center">
-                    <div>
-                      You are currently paying{' '}
-                      {`${subscriptionPrice}/${recur(subscriptionData.price)}`}{' '}
-                      for your membership
-                    </div>
-                  </div>
-                )
-              )}
-            </div> */}
-          </>
+          </div>
         ) : (
-          <>
+          <div className="w-full">
             {(viewer.is_pro || viewer.is_instructor) && (
               <p>
                 You still have access to a Pro Membership. If you feel this is
@@ -244,7 +170,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                 </a>
               </p>
             )}
-          </>
+          </div>
         )}
         {(subscriptionData?.subscription?.cancel_at_period_end ||
           subscriptionData?.portalUrl) && (

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -41,7 +41,6 @@ export async function loadUserAccounts({
             current_period_end
             stripe_subscription_id
             status
-            interval
           }
         }
       }

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -41,6 +41,7 @@ export async function loadUserAccounts({
             current_period_end
             stripe_subscription_id
             status
+            interval
           }
         }
       }

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {format} from 'date-fns'
 
 import {useAccount} from 'hooks/use-account'
-import {useViewer} from 'context/viewer-context'
 import SubscriptionDetails from 'components/pages/user/components/subscription-details'
 import {ItemWrapper} from 'components/pages/user/components/widget-wrapper'
 import AppLayout from 'components/app/layout'
@@ -12,7 +11,6 @@ import Invoices from 'components/invoices'
 import Spinner from 'components/spinner'
 
 const Membership = () => {
-  const {viewer} = useViewer()
   const {
     account,
     accountLoading,
@@ -22,9 +20,6 @@ const Membership = () => {
     hasStripeAccount,
     accountOwner,
   } = useAccount()
-
-  console.log({account})
-  console.log({viewer})
 
   switch (true) {
     case accountLoading:
@@ -64,7 +59,8 @@ const Membership = () => {
             You are a member of a team account.
           </h2>
           <p className="mb-6">
-            You have an access to all of our <strong>PRO</strong> resources.
+            You have an access to all of our <strong>PRO</strong>
+            <sup>⭐️</sup> resources.
           </p>
           <p>
             If this is incorrect, please reach out to{' '}
@@ -97,8 +93,9 @@ const Membership = () => {
         No Membership Found
       </h2>
       <p className="mb-3 md:mb-4">
-        You have access to all of our Free videos. You can subscribe for full
-        access to all of our Pro<sup>⭐️</sup> lessons any time.
+        You have access to all of our <strong>Free</strong> videos. You can
+        subscribe for full access to all of our Pro<sup>⭐️</sup> lessons any
+        time.
       </p>
       <p className="mb-12">
         If this is incorrect, please reach out to{' '}

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -30,13 +30,17 @@ const Membership = () => {
       )
     case isGiftMembership:
       return (
-        <div className="flex flex-col justify-center w-full">
+        <div className="flex flex-col justify-center w-full leading-relaxed">
           <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
             You have a pre-paid egghead membership.
           </h2>
-          <p className="w-fit mx-auto">
-            Your membership expires on:{' '}
+          <p>
+            You currently have <strong>PRO</strong>
+            <sup>⭐️</sup> access through a <strong>Gift Subscription</strong>{' '}
+            that ends on{' '}
             <strong>{format(new Date(giftExpiration), 'yyyy/MM/dd')}</strong>.
+            After that, you would need to subscribe to a <strong>Pro</strong>{' '}
+            plan to access our <strong>Pro</strong> materials.
           </p>
         </div>
       )
@@ -54,13 +58,22 @@ const Membership = () => {
       )
     case isTeamMember:
       return (
-        <div className="text-center w-full">
+        <div className="text-center w-full leading-relaxed">
           <h2 className="mb-4 md:mb-5 text-lg font-medium md:font-normal md:text-xl leading-none">
             You are a member of a team account.
           </h2>
-          <p className="mb-6">
-            You have an access to all of our <strong>PRO</strong>
-            <sup>⭐️</sup> resources.
+          <p className="mb-3 md:mb-4">
+            You have <strong>PRO</strong>
+            <sup>⭐️</sup> access through a team subscription managed by{' '}
+            <strong>
+              <a
+                href={`mailto:${accountOwner.email}`}
+                className="text-white hover:underline"
+              >
+                {accountOwner.email}
+              </a>
+            </strong>
+            .
           </p>
           <p>
             If this is incorrect, please reach out to{' '}
@@ -78,7 +91,7 @@ const Membership = () => {
                 href={`mailto:${accountOwner.email}`}
                 className="hover:underline duration-100"
               >
-                team member
+                team manager
               </a>
             </strong>
             .
@@ -88,7 +101,7 @@ const Membership = () => {
   }
 
   return (
-    <div className="w-full">
+    <div className="w-full leading-relaxed">
       <h2 className="mb-3 md:mb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
         No Membership Found
       </h2>

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {format} from 'date-fns'
 
+import {useAccount} from 'hooks/use-account'
+import {useViewer} from 'context/viewer-context'
 import SubscriptionDetails from 'components/pages/user/components/subscription-details'
 import {ItemWrapper} from 'components/pages/user/components/widget-wrapper'
 import AppLayout from 'components/app/layout'
@@ -8,9 +10,9 @@ import UserLayout from 'components/pages/user/components/user-layout'
 import PricingWidget from 'components/pricing/pricing-widget'
 import Invoices from 'components/invoices'
 import Spinner from 'components/spinner'
-import {useAccount} from 'hooks/use-account'
 
 const Membership = () => {
+  const {viewer} = useViewer()
   const {
     account,
     accountLoading,
@@ -21,16 +23,19 @@ const Membership = () => {
     accountOwner,
   } = useAccount()
 
+  console.log({account})
+  console.log({viewer})
+
   switch (true) {
     case accountLoading:
       return (
-        <div className="relative flex justify-center">
+        <div className="relative flex justify-center w-full">
           <Spinner className="w-6 h-6 text-gray-600" />
         </div>
       )
     case isGiftMembership:
       return (
-        <div className="flex flex-col justify-center">
+        <div className="flex flex-col justify-center w-full">
           <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
             You have a pre-paid egghead membership.
           </h2>
@@ -42,8 +47,8 @@ const Membership = () => {
       )
     case hasStripeAccount:
       return (
-        <div>
-          <ItemWrapper title="Subscription">
+        <div className="w-full">
+          <ItemWrapper title="Membership">
             <SubscriptionDetails
               stripeCustomerId={account.stripe_customer_id}
               slug={account.slug}
@@ -54,7 +59,7 @@ const Membership = () => {
       )
     case isTeamMember:
       return (
-        <div className="text-center">
+        <div className="text-center w-full">
           <h2 className="mb-4 md:mb-5 text-lg font-medium md:font-normal md:text-xl leading-none">
             You are a member of a team account.
           </h2>
@@ -88,10 +93,14 @@ const Membership = () => {
 
   return (
     <div className="w-full">
-      <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
-        No Subscription Found
+      <h2 className="mb-3 md:mb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
+        No Membership Found
       </h2>
-      <p className="w-fit mx-auto mb-12">
+      <p className="mb-3 md:mb-4">
+        You have access to all of our Free videos. You can subscribe for full
+        access to all of our Pro<sup>⭐️</sup> lessons any time.
+      </p>
+      <p className="mb-12">
         If this is incorrect, please reach out to{' '}
         <strong>
           <a


### PR DESCRIPTION
This updates the copy text for different memberships cases:

<details>
  <summary>Team Owner (active):</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763818-90ccdc5e-dfc7-4a35-9d11-051ac410496e.jpg">
</details>
<details>
  <summary>Team Owner (cancelled):</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763820-2935274d-09f7-4031-a50d-7247a98fbc57.jpg">
</details>
<details>
  <summary>Team Member:</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763816-3ba5f8d9-b251-423b-80ee-d06109f2c702.jpg">
</details>
<details>
  <summary>Gift Membership:</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763804-d4b450a5-377b-43a1-9178-2fbf89fcb84a.jpg">
</details>
<details>
  <summary>Individual Pro (active):</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763810-55d36aef-2e1d-4880-91e6-6751f8b1dc7e.jpg">
</details>
<details>
  <summary>Individual Pro (cancelled):</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763812-59b45e80-1c4b-47d0-9b25-c60d163c672b.jpg">
</details>
<details>
  <summary>Non-paid member:</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214763815-341302f9-0376-4a04-8a2b-0736a1e80751.jpg">
</details>

I think we could extend the text copy for the `team member` with `current_period_end` date but didn't found a way to get it being under `team member` account. In this user doesn't have neither `account` nor `subscriptionData` 🤔


![Art Loop GIF](https://user-images.githubusercontent.com/1519448/214764371-eb3e8738-9c8b-4f11-8c30-05ace3f068e0.gif)
