### PR TITLE
Fixes: EGG-40: allow team plan to cancel

### DIFF
--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -57,103 +57,106 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                 ⭐️ You're an <strong>egghead Member!</strong>
               </h3>
             )}
-            {isTeamAccountOwner && wasCanceled && (
-              <div className="w-full leading-relaxed mt-4 text-center">
-                <p>
-                  Your <strong>{recur(subscriptionData.price)}ly</strong> team
-                  membership for <strong>{number_of_members} seats</strong>{' '}
-                  (from <strong>{account?.capacity}</strong> available) is
-                  currently cancelled and it will not auto-renew.
-                </p>
-                <p>
-                  Your team will still have access until the end of your current
-                  billing period -{' '}
-                  <strong>
-                    {format(
-                      new Date(
-                        subscriptionData?.subscription?.current_period_end *
-                          1000,
-                      ),
-                      'yyyy/MM/dd',
-                    )}
-                  </strong>
-                  .
-                </p>
-                <p>
-                  You can renew at any time using the Manage Your Membership
-                  Billing button below.
-                </p>
-              </div>
-            )}
-            {isTeamAccountOwner && !wasCanceled && (
-              <div className="w-full leading-relaxed mt-4 text-center">
-                <p>
-                  Your <strong>{recur(subscriptionData.price)}ly</strong> team
-                  membership for <strong>{number_of_members} seats</strong>{' '}
-                  (from <strong>{account?.capacity}</strong> available) will
-                  automatically renew for <strong>{subscriptionPrice}</strong>{' '}
-                  on{' '}
-                  <strong>
-                    {format(
-                      new Date(account.subscriptions[0].current_period_end),
-                      'yyyy/MM/dd',
-                    )}
-                  </strong>
-                  .
-                </p>
-                <p>
-                  If you would like to cancel auto-renewal or change the number
-                  of seats for your team, you can use the Manage Your Membership
-                  Billing button below.
-                </p>
-              </div>
-            )}
-            {!isTeamAccountOwner && wasCanceled && (
-              <div className="w-full leading-relaxed mt-4 text-center">
-                <p>
-                  Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
-                  membership is currently cancelled and it will not auto-renew.
-                </p>
-                <p>
-                  You will still have access until the end of your current
-                  billing period -{' '}
-                  <strong>
-                    {format(
-                      new Date(
-                        subscriptionData?.subscription?.current_period_end *
-                          1000,
-                      ),
-                      'yyyy/MM/dd',
-                    )}
-                  </strong>
-                  .
-                </p>
-                <p>
-                  You can renew at any time using the Manage Your Membership
-                  Billing button below.
-                </p>
-              </div>
-            )}
-            {!isTeamAccountOwner && !wasCanceled && (
-              <div className="w-full leading-relaxed mt-4 text-center">
-                <p>
-                  Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
-                  membership will automatically renew for{' '}
-                  <strong>{subscriptionPrice}</strong> on{' '}
-                  <strong>
-                    {format(
-                      new Date(account.subscriptions[0].current_period_end),
-                      'yyyy/MM/dd',
-                    )}
-                  </strong>
-                  .
-                </p>
-                <p>
-                  If you would like to cancel auto-renewal you can use the
-                  Manage Your Membership Billing button below.
-                </p>
-              </div>
-            )}
+            <div className="w-full leading-relaxed mt-4 text-center">
+              {isTeamAccountOwner && wasCanceled && (
+                <>
+                  <p>
+                    Your <strong>{recur(subscriptionData.price)}ly</strong> team
+                    membership for <strong>{number_of_members} seats</strong>{' '}
+                    (from <strong>{account?.capacity}</strong> available) is
+                    currently cancelled and it will not auto-renew.
+                  </p>
+                  <p>
+                    Your team will still have access until the end of your
+                    current billing period -{' '}
+                    <strong>
+                      {format(
+                        new Date(
+                          subscriptionData?.subscription?.current_period_end *
+                            1000,
+                        ),
+                        'yyyy/MM/dd',
+                      )}
+                    </strong>
+                    .
+                  </p>
+                  <p>
+                    You can renew at any time using the Manage Your Membership
+                    Billing button below.
+                  </p>
+                </>
+              )}
+              {isTeamAccountOwner && !wasCanceled && (
+                <>
+                  <p>
+                    Your <strong>{recur(subscriptionData.price)}ly</strong> team
+                    membership for <strong>{number_of_members} seats</strong>{' '}
+                    (from <strong>{account?.capacity}</strong> available) will
+                    automatically renew for <strong>{subscriptionPrice}</strong>{' '}
+                    on{' '}
+                    <strong>
+                      {format(
+                        new Date(account.subscriptions[0].current_period_end),
+                        'yyyy/MM/dd',
+                      )}
+                    </strong>
+                    .
+                  </p>
+                  <p>
+                    If you would like to cancel auto-renewal or change the
+                    number of seats for your team, you can use the Manage Your
+                    Membership Billing button below.
+                  </p>
+                </>
+              )}
+              {!isTeamAccountOwner && wasCanceled && (
+                <>
+                  <p>
+                    Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
+                    membership is currently cancelled and it will not
+                    auto-renew.
+                  </p>
+                  <p>
+                    You will still have access until the end of your current
+                    billing period -{' '}
+                    <strong>
+                      {format(
+                        new Date(
+                          subscriptionData?.subscription?.current_period_end *
+                            1000,
+                        ),
+                        'yyyy/MM/dd',
+                      )}
+                    </strong>
+                    .
+                  </p>
+                  <p>
+                    You can renew at any time using the Manage Your Membership
+                    Billing button below.
+                  </p>
+                </>
+              )}
+              {!isTeamAccountOwner && !wasCanceled && (
+                <>
+                  <p>
+                    Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
+                    membership will automatically renew for{' '}
+                    <strong>{subscriptionPrice}</strong> on{' '}
+                    <strong>
+                      {format(
+                        new Date(account.subscriptions[0].current_period_end),
+                        'yyyy/MM/dd',
+                      )}
+                    </strong>
+                    .
+                  </p>
+                  <p>
+                    If you would like to cancel auto-renewal you can use the
+                    Manage Your Membership Billing button below.
+                  </p>
+                </>
+              )}
+            </div>
           </div>
         ) : (
           <div className="w-full">

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -19,7 +19,8 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
     const {subscriptionData, loading} = useSubscriptionDetails({
       stripeCustomerId,
     })
-    const {isTeamAccountOwner} = useAccount()
+    const {isTeamAccountOwner, account} = useAccount()
+    const {number_of_members} = account
 
     const subscriptionName = subscriptionData?.product?.name
     const subscriptionUnitAmount = get(
@@ -41,85 +42,136 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         minimumFractionDigits: 0,
       }).format(subscriptionUnitAmount / 100)
 
-    const currentPeriodEnd =
-      subscriptionData?.subscription?.cancel_at_period_end &&
-      subscriptionData?.subscription?.current_period_end * 1000
+    const wasCanceled = subscriptionData?.subscription?.cancel_at_period_end
 
     return !loading && subscriptionData ? (
       <div className="w-full">
         {subscriptionName ? (
-          <div className="md:w-[75ch] mx-auto">
-            {currentPeriodEnd && (
-              <div className="my-8 p-4 bg-red-100 rounded text-gray-900 space-y-2">
-                <p>
-                  Your membership is currently cancelled and it will not
-                  auto-renew. You'll have access until the end of your current
-                  billing period (
-                  <strong>
-                    {format(new Date(currentPeriodEnd), 'yyyy/MM/dd')}
-                  </strong>
-                  ). You can renew at any time.
-                </p>
-                <p>
-                  You can also get help by emailing{' '}
-                  <strong>
-                    <a
-                      href={`mailto:support@egghead.io?subject=${encodeURIComponent(
-                        `Support needed for egghead membership`,
-                      )}`}
-                      className="underline"
-                    >
-                      support@egghead.io
-                    </a>
-                  </strong>
-                  . We'll get back to you as soon as we can.
-                </p>
-              </div>
-            )}
+          <div className="w-full">
             {isTeamAccountOwner ? (
-              <h3 className="mb-2 text-lg font-medium text-center">
+              <h3 className="text-lg font-medium text-center">
                 ⭐️ You've got a team membership! ⭐️
               </h3>
             ) : (
-              <h3 className="mb-2 text-lg font-medium text-center">
+              <h3 className="text-lg font-medium text-center">
                 ⭐️ You're an <strong>egghead Member!</strong>
               </h3>
             )}
-            <p className="text-accents-5 text-center">
-              You can update your plan and payment information below via Stripe.
-            </p>
-            <div className="mt-8 mb-4 font-semibold">
-              {!subscriptionData?.portalUrl ? (
-                <div className="h-12 mb-6">loading</div>
-              ) : (
-                subscriptionPrice &&
-                !subscriptionData?.subscription?.cancel_at_period_end && (
-                  <div className="flex space-x-2 justify-center">
-                    <div>
-                      You are currently paying{' '}
-                      {`${subscriptionPrice}/${recur(subscriptionData.price)}`}{' '}
-                      for your membership
-                    </div>
-                  </div>
-                )
-              )}
-            </div>
+            {isTeamAccountOwner && wasCanceled && (
+              <div className="w-full leading-relaxed mt-4">
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong> team
+                  membership for <strong>{number_of_members} seats</strong>{' '}
+                  (from <strong>{account?.capacity}</strong> available) is
+                  currently cancelled and it will not auto-renew.
+                </p>
+                <p>
+                  Your team will still have access until the end of your current
+                  billing period -{' '}
+                  <strong>
+                    {format(
+                      new Date(
+                        subscriptionData?.subscription?.current_period_end *
+                          1000,
+                      ),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  You can renew at any time using the Manage Your Membership
+                  Billing button below.
+                </p>
+              </div>
+            )}
+            {isTeamAccountOwner && !wasCanceled && (
+              <div className="w-full leading-relaxed mt-4">
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong> team
+                  membership for <strong>{number_of_members} seats</strong>{' '}
+                  (from <strong>{account?.capacity}</strong> available) will
+                  automatically renew for <strong>{subscriptionPrice}</strong>{' '}
+                  on{' '}
+                  <strong>
+                    {format(
+                      new Date(account.subscriptions[0].current_period_end),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  If you would like to cancel auto-renewal or change the number
+                  of seats for your team, you can use the Manage Your Membership
+                  Billing button below.
+                </p>
+              </div>
+            )}
+            {!isTeamAccountOwner && wasCanceled && (
+              <div className="w-full leading-relaxed mt-4">
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
+                  membership is currently cancelled and it will not auto-renew.
+                </p>
+                <p>
+                  You will still have access until the end of your current
+                  billing period -{' '}
+                  <strong>
+                    {format(
+                      new Date(
+                        subscriptionData?.subscription?.current_period_end *
+                          1000,
+                      ),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  You can renew at any time using the Manage Your Membership
+                  Billing button below.
+                </p>
+              </div>
+            )}
+            {!isTeamAccountOwner && !wasCanceled && (
+              <div className="w-full leading-relaxed mt-4">
+                <p>
+                  Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
+                  membership will automatically renew for{' '}
+                  <strong>{subscriptionPrice}</strong> on{' '}
+                  <strong>
+                    {format(
+                      new Date(account.subscriptions[0].current_period_end),
+                      'yyyy/MM/dd',
+                    )}
+                  </strong>
+                  .
+                </p>
+                <p>
+                  If you would like to cancel auto-renewal you can use the
+                  Manage Your Membership Billing button below.
+                </p>
+              </div>
+            )}
           </div>
         ) : (
-          <>
+          <div className="w-full">
             {(viewer.is_pro || viewer.is_instructor) && (
               <p>
                 You still have access to a Pro Membership. If you feel this is
                 in error please email{' '}
                 <a
                   className="text-blue-600 underline hover:text-blue-700"
-                  href="mailto:support@egghead.io"
+                  href={`mailto:support@egghead.io?subject=${encodeURIComponent(
+                    `Support needed for egghead membership`,
+                  )}`}
                 >
                   support@egghead.io
                 </a>
               </p>
             )}
-          </>
+          </div>
         )}
         {(subscriptionData?.subscription?.cancel_at_period_end ||
           subscriptionData?.portalUrl) && (

--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -58,7 +58,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </h3>
             )}
             {isTeamAccountOwner && wasCanceled && (
-              <div className="w-full leading-relaxed mt-4">
+              <div className="w-full leading-relaxed mt-4 text-center">
                 <p>
                   Your <strong>{recur(subscriptionData.price)}ly</strong> team
                   membership for <strong>{number_of_members} seats</strong>{' '}
@@ -86,7 +86,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </div>
             )}
             {isTeamAccountOwner && !wasCanceled && (
-              <div className="w-full leading-relaxed mt-4">
+              <div className="w-full leading-relaxed mt-4 text-center">
                 <p>
                   Your <strong>{recur(subscriptionData.price)}ly</strong> team
                   membership for <strong>{number_of_members} seats</strong>{' '}
@@ -109,7 +109,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </div>
             )}
             {!isTeamAccountOwner && wasCanceled && (
-              <div className="w-full leading-relaxed mt-4">
+              <div className="w-full leading-relaxed mt-4 text-center">
                 <p>
                   Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
                   membership is currently cancelled and it will not auto-renew.
@@ -135,7 +135,7 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
               </div>
             )}
             {!isTeamAccountOwner && !wasCanceled && (
-              <div className="w-full leading-relaxed mt-4">
+              <div className="w-full leading-relaxed mt-4 text-center">
                 <p>
                   Your <strong>{recur(subscriptionData.price)}ly</strong>{' '}
                   membership will automatically renew for{' '}

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -116,7 +116,9 @@ const Membership = () => {
         If this is incorrect, please reach out to{' '}
         <strong>
           <a
-            href="mailto:support@egghead.io"
+            href={`mailto:support@egghead.io?subject=${encodeURIComponent(
+              `Support needed for egghead team membership`,
+            )}`}
             className="hover:underline duration-100"
           >
             support@egghead.io

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -30,7 +30,7 @@ const Membership = () => {
       )
     case isGiftMembership:
       return (
-        <div className="flex flex-col justify-center w-full leading-relaxed">
+        <div className="flex flex-col justify-center w-full leading-relaxed text-center">
           <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl">
             You have a pre-paid egghead membership.
           </h2>
@@ -117,7 +117,7 @@ const Membership = () => {
         <strong>
           <a
             href={`mailto:support@egghead.io?subject=${encodeURIComponent(
-              `Support needed for egghead team membership`,
+              `Support needed for egghead membership`,
             )}`}
             className="hover:underline duration-100"
           >

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {format} from 'date-fns'
 
+import {useAccount} from 'hooks/use-account'
 import SubscriptionDetails from 'components/pages/user/components/subscription-details'
 import {ItemWrapper} from 'components/pages/user/components/widget-wrapper'
 import AppLayout from 'components/app/layout'
@@ -8,7 +9,6 @@ import UserLayout from 'components/pages/user/components/user-layout'
 import PricingWidget from 'components/pricing/pricing-widget'
 import Invoices from 'components/invoices'
 import Spinner from 'components/spinner'
-import {useAccount} from 'hooks/use-account'
 
 const Membership = () => {
   const {
@@ -24,26 +24,30 @@ const Membership = () => {
   switch (true) {
     case accountLoading:
       return (
-        <div className="relative flex justify-center">
+        <div className="relative flex justify-center w-full">
           <Spinner className="w-6 h-6 text-gray-600" />
         </div>
       )
     case isGiftMembership:
       return (
-        <div className="flex flex-col justify-center">
-          <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
+        <div className="flex flex-col justify-center w-full leading-relaxed">
+          <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl">
             You have a pre-paid egghead membership.
           </h2>
-          <p className="w-fit mx-auto">
-            Your membership expires on:{' '}
+          <p>
+            You currently have <strong>PRO</strong>
+            <sup>⭐️</sup> access through a <strong>Gift Subscription</strong>{' '}
+            that ends on{' '}
             <strong>{format(new Date(giftExpiration), 'yyyy/MM/dd')}</strong>.
+            After that, you would need to subscribe to a <strong>Pro</strong>{' '}
+            plan to access our <strong>Pro</strong> materials.
           </p>
         </div>
       )
     case hasStripeAccount:
       return (
-        <div>
-          <ItemWrapper title="Subscription">
+        <div className="w-full">
+          <ItemWrapper title="Membership">
             <SubscriptionDetails
               stripeCustomerId={account.stripe_customer_id}
               slug={account.slug}
@@ -54,12 +58,22 @@ const Membership = () => {
       )
     case isTeamMember:
       return (
-        <div className="text-center">
+        <div className="text-center w-full leading-relaxed">
           <h2 className="mb-4 md:mb-5 text-lg font-medium md:font-normal md:text-xl leading-none">
             You are a member of a team account.
           </h2>
-          <p className="mb-6">
-            You have an access to all of our <strong>PRO</strong> resources.
+          <p className="mb-3 md:mb-4">
+            You have <strong>PRO</strong>
+            <sup>⭐️</sup> access through a team subscription managed by{' '}
+            <strong>
+              <a
+                href={`mailto:${accountOwner.email}`}
+                className="text-white hover:underline"
+              >
+                {accountOwner.email}
+              </a>
+            </strong>
+            .
           </p>
           <p>
             If this is incorrect, please reach out to{' '}
@@ -79,7 +93,7 @@ const Membership = () => {
                 href={`mailto:${accountOwner.email}`}
                 className="hover:underline duration-100"
               >
-                team member
+                team manager
               </a>
             </strong>
             .
@@ -89,11 +103,16 @@ const Membership = () => {
   }
 
   return (
-    <div className="w-full">
-      <h2 className="pb-3 md:pb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
-        No Subscription Found
+    <div className="w-full leading-relaxed">
+      <h2 className="mb-3 md:mb-4 text-lg font-medium md:font-normal md:text-xl leading-none w-fit mx-auto">
+        No Membership Found
       </h2>
-      <p className="w-fit mx-auto mb-12">
+      <p className="mb-3 md:mb-4">
+        You have access to all of our <strong>Free</strong> videos. You can
+        subscribe for full access to all of our Pro<sup>⭐️</sup> lessons any
+        time.
+      </p>
+      <p className="mb-12">
         If this is incorrect, please reach out to{' '}
         <strong>
           <a


### PR DESCRIPTION
This updates the copy text for different memberships cases:

<details>
  <summary>Team Owner (active)</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943037-f1734ec1-3cf6-4a09-94ae-d4dfef2ddd80.jpg">
</details>
<details>
  <summary>Team Owner (cancelled)</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943046-7ed870b8-0306-4bd2-9fc3-0a16c07c6a4b.jpg">
</details>
<details>
  <summary>Team Member</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943033-bc288c0c-b4a5-45dd-9bed-40b864bde933.jpg">
</details>
<details>
  <summary>Gift Membership</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943013-c014ec07-261a-4710-b8b6-1d77cbeaed1d.jpg">
</details>
<details>
  <summary>Individual Pro (active)</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943019-84a9f452-041f-4937-97bc-3abae9441b92.jpg">
</details>
<details>
  <summary>Individual Pro (cancelled)</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943027-4037e2d6-4b87-4584-bb6a-06492106a523.jpg">
</details>
<details>
  <summary>Non-paid member</summary>
  <img width="1200" src="https://user-images.githubusercontent.com/1519448/214943029-42a73018-3153-4d90-b25a-6bb0330c3ef9.jpg">
</details>

I think we could extend the text copy for the `team member` with `current_period_end` date but didn't found a way to get it being under `team member` account. In this user doesn't have neither `account` nor `subscriptionData` 🤔

![Art Loop GIF](https://user-images.githubusercontent.com/1519448/214941898-ff34a86a-853a-4551-bb6c-bff03f353bd1.gif)
