### PR TITLE
honor coupon codes

### DIFF
--- a/src/machines/commerce-machine.ts
+++ b/src/machines/commerce-machine.ts
@@ -5,7 +5,7 @@ import {PricingData} from 'types'
 
 type CouponToApply = {
   couponCode: string
-  couponType: 'ppp' | 'default'
+  couponType: 'ppp' | 'special' | 'default'
 }
 
 const findAvailablePPPCoupon = (pricingData: PricingData) => {
@@ -22,7 +22,7 @@ const extractAppliedDefaultCoupon = (
   const appliedCoupon = pricingData?.applied_coupon
 
   // no applied default coupon found
-  if (isEmpty(availableDefaultCoupon) || isEmpty(appliedCoupon)) {
+  if (isEmpty(availableDefaultCoupon) && isEmpty(appliedCoupon)) {
     return {}
   }
 
@@ -34,6 +34,17 @@ const extractAppliedDefaultCoupon = (
       couponToApply: {
         couponCode: appliedCoupon.coupon_code,
         couponType: 'default',
+      },
+    }
+  }
+
+  // if we have an appliedCoupon that isn't region restricted and not default
+  // we want to honor it
+  if (appliedCoupon && !appliedCoupon.coupon_region_restricted) {
+    return {
+      couponToApply: {
+        couponCode: appliedCoupon.coupon_code,
+        couponType: 'special',
       },
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,7 @@ export type Prices = {
 export type Coupon = {
   coupon_code: string
   coupon_discount: number
+  coupon_region_restricted: boolean
   coupon_region_restricted_to: string
   coupon_region_restricted_to_name: string
   coupon_expires_at: number


### PR DESCRIPTION
if a coupon was passed in as a query param it was being cast aside and not applied to the checkout session only the price check so a displayed price didn't match the stripe checkout price

![coupon](https://media.giphy.com/media/xT5LMGUdnNTQ4UISJy/giphy.gif)