### PR TITLE
let instructors know they are instructors

### DIFF
--- a/src/hooks/use-account.ts
+++ b/src/hooks/use-account.ts
@@ -9,8 +9,6 @@ export const useAccount = () => {
 
   const isInstructor = viewer?.is_instructor
 
-  console.log({isInstructor})
-
   const isActiveAccountMember = userAccounts?.some(
     (account: {members: {id: number}[]}) => {
       return account.members?.find((member: {id: number}) => {

--- a/src/hooks/use-account.ts
+++ b/src/hooks/use-account.ts
@@ -7,6 +7,10 @@ export const useAccount = () => {
   const {data: userAccounts, status: accountLoadingStatus} =
     trpc.user.accountsForCurrent.useQuery()
 
+  const isInstructor = viewer?.is_instructor
+
+  console.log({isInstructor})
+
   const isActiveAccountMember = userAccounts?.some(
     (account: {members: {id: number}[]}) => {
       return account.members?.find((member: {id: number}) => {
@@ -77,6 +81,7 @@ export const useAccount = () => {
     isTeamMember,
     hasStripeAccount,
     isDisabled,
+    isInstructor,
     accountLoading: accountLoadingStatus === 'loading',
     accountOwner: userAccounts?.find((account: any) => account?.owner)?.owner,
   }

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -20,9 +20,27 @@ const Membership = () => {
     hasStripeAccount,
     accountOwner,
     isDisabled,
+    isInstructor,
   } = useAccount()
 
   switch (true) {
+    case isInstructor:
+      return (
+        <>
+          <div className="sm:h-[50vh] md:w-[75ch] mx-auto">
+            <div className="w-full leading-relaxed mt-8 text-center place-items-center">
+              <h3 className="text-xl font-medium text-center">
+                ✨ You are an egghead instructor ✨
+              </h3>
+              <p className="mt-4">
+                You have lifetime access to all of our courses. If you have an
+                active membership, please reach out to egghead staff if you'd
+                like it canceled.
+              </p>
+            </div>
+          </div>
+        </>
+      )
     case isDisabled:
       return (
         <>


### PR DESCRIPTION
We currently ask instructors to sign up for egghead on the membership page because no membership is found. This PR checks if `is_instructor` is set to true and short circuits membership logic to let them know they are an instructor. Also added that if they have an active membership to let egghead staff know and we can cancel it for them.

![vip](https://media4.giphy.com/media/hKYigb3Djp8pa/giphy.gif?cid=1927fc1bw4ocxgvox7iw9jvbcx64xd67azm4hlqw2wb319q3&rid=giphy.gif&ct=g)

![Desktop](https://user-images.githubusercontent.com/6188161/216450119-f6055c16-e881-4a9f-aad6-d08e242f4e87.png)
![mobile](https://user-images.githubusercontent.com/6188161/216450130-32342821-f17f-493e-a069-dfe56bd317a4.png)
