### PR TITLE
Fixes EGG-173: display lesson completion

### DIFF
--- a/src/components/card/search-hit-resource-card.tsx
+++ b/src/components/card/search-hit-resource-card.tsx
@@ -25,6 +25,7 @@ const SearchHitResourceCard: React.FC<{
   className?: string
   small?: boolean
   completedCoursesIds: string[]
+  completeLessonsSlugs: string[]
 }> = ({
   children,
   resource,
@@ -33,8 +34,11 @@ const SearchHitResourceCard: React.FC<{
   describe = true,
   small = false,
   completedCoursesIds,
+  completeLessonsSlugs,
   ...props
 }) => {
+  const isLessonCompleted =
+    resource?.type === 'lesson' && completeLessonsSlugs?.includes(resource.slug)
   const isCourseCompleted =
     !isEmpty(completedCoursesIds) &&
     resource.id &&
@@ -72,7 +76,7 @@ const SearchHitResourceCard: React.FC<{
                 aria-hidden
                 className="uppercase font-medium sm:text-[0.65rem] text-[0.55rem] pb-1 text-gray-700 dark:text-indigo-100 flex items-center"
               >
-                {isCourseCompleted && (
+                {(isCourseCompleted || isLessonCompleted) && (
                   <span title="Course completed" className=" text-green-500">
                     <CheckIcon />
                   </span>

--- a/src/components/search/components/hit/index.tsx
+++ b/src/components/search/components/hit/index.tsx
@@ -4,11 +4,13 @@ import {SearchHitResourceCard} from 'components/card/search-hit-resource-card'
 type HitComponentProps = {
   hit: any
   completedCoursesIds: string[]
+  completeLessonsSlugs: string[]
 }
 
 const HitComponent: FunctionComponent<HitComponentProps> = ({
   hit,
   completedCoursesIds,
+  completeLessonsSlugs,
 }) => {
   const {image, type, instructor_url, instructor_name, instructor} = hit
 
@@ -41,6 +43,7 @@ const HitComponent: FunctionComponent<HitComponentProps> = ({
         },
       }}
       completedCoursesIds={completedCoursesIds}
+      completeLessonsSlugs={completeLessonsSlugs}
     />
   )
 }

--- a/src/components/search/hits.tsx
+++ b/src/components/search/hits.tsx
@@ -4,13 +4,22 @@ import {useQuery} from '@tanstack/react-query'
 import {connectHits} from 'react-instantsearch-dom'
 import HitComponent from './components/hit'
 import {useViewer} from 'context/viewer-context'
-import {loadUserCompletedCourses} from 'lib/users'
+import {loadUserCompletedCourses, loadUserCompletedLessons} from 'lib/users'
 
 const useUserCompletedCourses = (viewerId: number) => {
   return useQuery(['completeCourses'], async () => {
     if (viewerId) {
       const {completeCourses} = await loadUserCompletedCourses()
       return completeCourses
+    }
+  })
+}
+
+const useUserCompletedLessons = (viewerId: number) => {
+  return useQuery(['completeLessons'], async () => {
+    if (viewerId) {
+      const {completeLessons} = await loadUserCompletedLessons()
+      return completeLessons
     }
   })
 }
@@ -23,6 +32,7 @@ const CustomHits: FunctionComponent<CustomHitsProps> = ({hits}) => {
   const {viewer} = useViewer()
   const viewerId = viewer?.id
   const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const {data: completeLessonsSlugs} = useUserCompletedLessons(viewerId)
   const completedCoursesIds =
     !isEmpty(completeCourseData) &&
     completeCourseData.map((course: any) => course.collection.id)
@@ -34,6 +44,7 @@ const CustomHits: FunctionComponent<CustomHitsProps> = ({hits}) => {
             key={hit.objectID}
             hit={hit}
             completedCoursesIds={completedCoursesIds}
+            completeLessonsSlugs={completeLessonsSlugs}
           />
         )
       })}

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -171,7 +171,6 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
       title
       description
       duration
-      completed
       free_forever
       path
       transcript

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -171,6 +171,7 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
       title
       description
       duration
+      completed
       free_forever
       path
       transcript

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -196,12 +196,6 @@ export async function loadUserCompletedCourses(token?: string): Promise<any> {
             image: image_thumb_url
             path
             id
-            lessons {
-              title
-              slug
-              path
-              completed
-            }
           }
           ... on Course {
             title
@@ -209,7 +203,6 @@ export async function loadUserCompletedCourses(token?: string): Promise<any> {
               title
               slug
               path
-              completed
             }
             image: image_thumb_url
             type


### PR DESCRIPTION
This adds lesson completion label on the lessons cards on the search page. However, the approach I used doesn't work with lessons that don't belong to any collection/playlist (like this one: https://egghead.io/lessons/react-using-react-with-the-fullcalendar-jquery-plugin), I didn't find the solution for this case yet.

![completed](https://user-images.githubusercontent.com/1519448/220509632-234c308b-71d3-4ea1-908d-990888efa3af.gif)


