### PR TITLE
fix: add redirect for broken old solid article link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -160,6 +160,11 @@ const searchRoutes = [
 
 const legacyRoutes = [
   {
+    source: `/blog/manage-reactive-state-with-solid-js-signals`,
+    destination: `/blog/manage-reactive-state-with-solidjs-signals`,
+    permanent: true,
+  },
+  {
     source: `/user/subscription`,
     destination: `/user/membership`,
     permanent: true,


### PR DESCRIPTION
![redirect](https://media0.giphy.com/media/oYyNedGfw8CTq00Whz/giphy.gif?cid=1927fc1budsztbgil3aiyqy3zxyupc8s5u18ki47l0gz5mrv&rid=giphy.gif&ct=g)