### PR TITLE
fixes [EGG-181]: display team account when present

### DIFF
--- a/src/components/pages/user/components/subscription-details.tsx
+++ b/src/components/pages/user/components/subscription-details.tsx
@@ -13,6 +13,22 @@ type SubscriptionDetailsProps = {
   slug: string
 }
 
+const formatAmountWithCurrency = (
+  amountInCents: number,
+  currency: string,
+): string => {
+  if (!amountInCents || !currency) return ''
+
+  let positiveAmount = Math.abs(amountInCents)
+  let formattedAmount = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency,
+    minimumFractionDigits: 0,
+  }).format(positiveAmount / 100)
+
+  return formattedAmount
+}
+
 const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
   ({stripeCustomerId, slug}) => {
     const {viewer} = useViewer()
@@ -40,6 +56,11 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
         currency: currency,
         minimumFractionDigits: 0,
       }).format(subscriptionUnitAmount / 100)
+
+    const accountBalance =
+      subscriptionData?.accountBalance && currency
+        ? formatAmountWithCurrency(subscriptionData?.accountBalance, currency)
+        : 0
 
     const pendingCancelation =
       subscriptionData?.subscription?.cancel_at_period_end
@@ -112,6 +133,14 @@ const SubscriptionDetails: React.FunctionComponent<SubscriptionDetailsProps> =
                 <h3 className="text-lg font-medium text-center mb-4">
                   ⭐️ You manage a team membership! ⭐️
                 </h3>
+                {subscriptionData?.accountBalance &&
+                subscriptionData?.accountBalance < 0 ? (
+                  <p>
+                    You're account has a{' '}
+                    <strong>credit of {accountBalance}</strong> which will be
+                    applied to your next payment.
+                  </p>
+                ) : null}
                 <p>
                   Your {recur(subscriptionData.price)}ly team membership of{' '}
                   {account?.capacity} seats will{' '}

--- a/src/components/team/billing-section.tsx
+++ b/src/components/team/billing-section.tsx
@@ -13,11 +13,22 @@ const formatAmountWithCurrency = (
 ): string => {
   if (!amountInCents || !currency) return ''
 
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 0,
-  }).format(amountInCents / 100)
+  if (amountInCents < 0) {
+    let positiveAmount = Math.abs(amountInCents)
+    let formattedAmount = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+      minimumFractionDigits: 0,
+    }).format(positiveAmount / 100)
+
+    return `(${formattedAmount})`
+  } else {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+      minimumFractionDigits: 0,
+    }).format(amountInCents / 100)
+  }
 }
 
 const isValidDate = (date: any) => {
@@ -33,6 +44,10 @@ const BillingSection = ({stripeCustomerId}: {stripeCustomerId: string}) => {
 
   const currency = subscriptionData.latestInvoice?.currency || 'USD'
   const recurrence = recur(subscriptionData?.price)
+
+  const accountBalanceDisplay = subscriptionData?.accountBalance
+    ? formatAmountWithCurrency(subscriptionData?.accountBalance, currency)
+    : 0
 
   let subscriptionName, subscriptionDescription
 
@@ -176,6 +191,12 @@ const BillingSection = ({stripeCustomerId}: {stripeCustomerId: string}) => {
                 Next Billing Date
               </span>
               <span className="">{nextBillDateDisplay}</span>
+            </div>
+            <div className="flex flex-col space-y-0.5">
+              <span className="font-semibold text-sm text-gray-500 dark:text-gray-400">
+                Account Balance
+              </span>
+              <span className="">{accountBalanceDisplay}</span>
             </div>
             <div className="flex flex-row space-x-8">
               <div className="flex flex-col space-y-0.5">

--- a/src/trpc/routers/subscription-detail.ts
+++ b/src/trpc/routers/subscription-detail.ts
@@ -57,7 +57,6 @@ export const subscriptionDetailsRouter = router({
             customer: stripeCustomerId,
           })
         }
-        console.log({session, customer, subscriptions})
 
         return {
           portalUrl: session.url,


### PR DESCRIPTION
In the case that a team downsizes the number of seats on the team and accrues credit on their stripe account we want to display that credited amount to them. 

## /membership page
![has credit](https://user-images.githubusercontent.com/6188161/226448129-0e4d5976-862c-4ac9-b0d4-7fb5dd8a163e.png)
![has no credit](https://user-images.githubusercontent.com/6188161/226448157-108b0088-0bac-437f-903c-93e5b7b4f15c.png)

## /team page
![has credit](https://user-images.githubusercontent.com/6188161/226448445-02b1a408-4366-497e-8060-4cdda46831ac.png)
![has no credit](https://user-images.githubusercontent.com/6188161/226447775-6a9c060a-dd3b-4920-a1f2-39985399d34f.png)


![nice](https://media2.giphy.com/media/Od0QRnzwRBYmDU3eEO/giphy.gif?cid=1927fc1bd5wc7fypzz0ajvpefquoko71w6ekdtiv0e2bnn46&rid=giphy.gif&ct=g)