### PR TITLE
Zac/egg 183 ability to manually toggle lesson

### DIFF
--- a/src/components/layouts/multi-module-collection-page-layout.tsx
+++ b/src/components/layouts/multi-module-collection-page-layout.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import Image from 'next/image'
 import Markdown from 'react-markdown'
 import toast from 'react-hot-toast'
-import {useQuery} from '@tanstack/react-query'
 import InstructorProfile from 'components/pages/courses/instructor-profile'
 import PlayIcon from 'components/pages/courses/play-icon'
 import getDependencies from 'data/courseDependencies'
@@ -35,6 +34,7 @@ import MembershipDialogButton from '../pages/courses/membership-dialog-button'
 import {loadUserCompletedCourses} from 'lib/users'
 
 import LoginForm from 'pages/login'
+import {trpc} from 'trpc/trpc.client'
 
 type CoursePageLayoutProps = {
   lessons: any
@@ -122,15 +122,6 @@ export const PeopleCompleted: React.FunctionComponent<{count: number}> = ({
   </div>
 )
 
-const useCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
-}
-
 const MultiModuleCollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> =
   ({lessons = [], course, ogImageUrl}) => {
     const courseDependencies: any = getDependencies(course.slug)
@@ -138,10 +129,10 @@ const MultiModuleCollectionPageLayout: React.FunctionComponent<CoursePageLayoutP
     const [clickable, setIsClickable] = React.useState(true)
     const {viewer} = useViewer()
     const viewerId = viewer?.id
-    const {data: completedCourses} = useCompletedCourses(viewerId)
+    const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
     const isCourseCompleted =
-      !isEmpty(completedCourses) &&
-      completedCourses.some(
+      !isEmpty(completeCourseData) &&
+      completeCourseData.some(
         (courseItem: any) => courseItem?.collection?.slug === course.slug,
       )
     const defaultPairWithResources: any[] = take(

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {useRouter} from 'next/router'
-import {useQuery} from '@tanstack/react-query'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
 import Search from 'components/pages/home/search'
@@ -10,29 +9,16 @@ import {CardResource} from 'types'
 import Grid from 'components/grid'
 import Image from 'next/image'
 import Link from 'next/link'
-import {track} from 'utils/analytics'
 import Jumbotron from 'components/pages/home/jumbotron'
-import {Jumbotron as HolidayReleaseJumbotron} from 'components/pages/20-days-of-egghead/course-grid'
 import toast, {Toaster} from 'react-hot-toast'
 import analytics from 'utils/analytics'
-import {loadUserCompletedCourses} from 'lib/users'
 import {useViewer} from 'context/viewer-context'
 import {isEmpty} from 'lodash'
-
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
-}
+import {trpc} from 'trpc/trpc.client'
 
 const Home: React.FC<any> = ({data, jumbotron, location}) => {
   const router = useRouter()
-  const {viewer} = useViewer()
-  const viewerId = viewer?.id
-  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
   const completedCoursesIds =
     !isEmpty(completeCourseData) &&
     completeCourseData.map((course: any) => course.collection.id)

--- a/src/components/pages/user/tabs-content/activity-tab-content.tsx
+++ b/src/components/pages/user/tabs-content/activity-tab-content.tsx
@@ -9,6 +9,7 @@ import {
   LearnerStats,
 } from 'components/pages/user/components'
 import {ItemWrapper} from 'components/pages/user/components/widget-wrapper'
+import {trpc} from 'trpc/trpc.client'
 
 const useProgressForUser = (viewerId: number) => {
   return useQuery(['progress'], async () => {
@@ -26,32 +27,22 @@ const useProgressForUser = (viewerId: number) => {
   })
 }
 
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-
-      return completeCourses
-    }
-  })
-}
-
 const ActivityTabContent: React.FC<any> = () => {
   const {viewer, authToken} = useViewer()
   const viewerId = viewer?.id
   const {status: progressStatus, data: progressData} =
     useProgressForUser(viewerId)
-  let {
-    status: completedCourseStatus,
+  const {
     data: completeCourseData,
+    status: completeCourseStatus,
     error: completeCourseError,
-  } = useUserCompletedCourses(viewerId)
-  const completedCourseCount = !!completeCourseData?.length
+  } = trpc.progress.completedCourses.useQuery()
+  const completeCourseCount = !!completeCourseData?.length
     ? completeCourseData?.length
     : 0
   const learnerStatsData = {
     ...progressData?.completionStats,
-    completedCourseCount,
+    completeCourseCount,
   }
 
   return (
@@ -71,8 +62,8 @@ const ActivityTabContent: React.FC<any> = () => {
       <ItemWrapper title="Completed Courses">
         <CompletedCourses
           completeCourseData={completeCourseData}
-          completedCourseStatus={completedCourseStatus}
-          completedCourseCount={completedCourseCount}
+          completedCourseStatus={completeCourseStatus}
+          completedCourseCount={completeCourseCount}
         />
       </ItemWrapper>
     </div>

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import {useQuery} from '@tanstack/react-query'
 import Grid from 'components/grid'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
@@ -10,17 +9,7 @@ import cx from 'classnames'
 import {NextSeo} from 'next-seo'
 import {CARD_TYPES} from 'components/search/curated/curated-essential'
 import {useRouter} from 'next/router'
-import {useViewer} from 'context/viewer-context'
-import {loadUserCompletedCourses} from 'lib/users'
-
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
-}
+import {trpc} from 'trpc/trpc.client'
 
 type CuratedTopicProps = {
   topicData: any
@@ -36,9 +25,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
     topic.label
   } Tutorials for ${new Date().getFullYear()}`
   const router = useRouter()
-  const {viewer} = useViewer()
-  const viewerId = viewer?.id
-  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
   const completedCoursesIds =
     !isEmpty(completeCourseData) &&
     completeCourseData.map((course: any) => course.collection.id)

--- a/src/components/search/hits.tsx
+++ b/src/components/search/hits.tsx
@@ -1,18 +1,13 @@
 import React, {FunctionComponent} from 'react'
 import {isEmpty} from 'lodash'
-import {useQuery} from '@tanstack/react-query'
 import {connectHits} from 'react-instantsearch-dom'
 import HitComponent from './components/hit'
-import {useViewer} from 'context/viewer-context'
-import {loadUserCompletedCourses} from 'lib/users'
+import {trpc} from 'trpc/trpc.client'
 
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
+const useUserCompletedCourses = () => {
+  const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
+
+  return completeCourseData
 }
 
 type CustomHitsProps = {
@@ -20,9 +15,7 @@ type CustomHitsProps = {
 }
 
 const CustomHits: FunctionComponent<CustomHitsProps> = ({hits}) => {
-  const {viewer} = useViewer()
-  const viewerId = viewer?.id
-  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+  const {data: completeCourseData} = useUserCompletedCourses()
   const completedCoursesIds =
     !isEmpty(completeCourseData) &&
     completeCourseData.map((course: any) => course.collection.id)

--- a/src/components/search/hits.tsx
+++ b/src/components/search/hits.tsx
@@ -2,12 +2,17 @@ import React, {FunctionComponent} from 'react'
 import {isEmpty} from 'lodash'
 import {connectHits} from 'react-instantsearch-dom'
 import HitComponent from './components/hit'
-import {trpc} from 'trpc/trpc.client'
+import {useViewer} from 'context/viewer-context'
+import {loadUserCompletedCourses} from 'lib/users'
+import {useQuery} from '@tanstack/react-query'
 
-const useUserCompletedCourses = () => {
-  const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
-
-  return completeCourseData
+const useUserCompletedCourses = (viewerId: number) => {
+  return useQuery(['completeCourses'], async () => {
+    if (viewerId) {
+      const {completeCourses} = await loadUserCompletedCourses()
+      return completeCourses
+    }
+  })
 }
 
 type CustomHitsProps = {
@@ -15,7 +20,10 @@ type CustomHitsProps = {
 }
 
 const CustomHits: FunctionComponent<CustomHitsProps> = ({hits}) => {
-  const {data: completeCourseData} = useUserCompletedCourses()
+  const {viewer} = useViewer()
+  const viewerId = viewer?.id
+  const {data: completeCourseData} = useUserCompletedCourses(viewerId)
+
   const completedCoursesIds =
     !isEmpty(completeCourseData) &&
     completeCourseData.map((course: any) => course.collection.id)

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -167,6 +167,8 @@ export async function loadLesson(
 const loadLessonGraphQLQuery = /* GraphQL */ `
   query getLesson($slug: String!) {
     lesson(slug: $slug) {
+      id
+      completed
       slug
       title
       description
@@ -193,6 +195,7 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
       published_at
       collection {
         ... on Playlist {
+          id
           title
           slug
           type
@@ -210,6 +213,7 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
           }
         }
         ... on Course {
+          id
           title
           slug
           type

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -16,6 +16,18 @@ const PlaylistProgressSchema = z
   })
   .nullish()
 
+const LessonProgressSchema = z
+  .object({
+    lessonProgress: z.object({
+      completed: z.boolean(),
+      title: z.string(),
+      slug: z.string(),
+      path: z.string(),
+    }),
+  })
+
+  .nullish()
+
 export type PlaylistProgress = z.infer<typeof PlaylistProgressSchema>
 
 export async function loadPlaylistProgress({
@@ -48,3 +60,31 @@ export async function loadPlaylistProgress({
   )
   return PlaylistProgressSchema.parse(progress)
 }
+
+export async function loadLessonProgress({
+  token,
+  slug,
+}: {
+  token?: string
+  slug: string
+}) {
+  const query = gql`
+    query getLessonProgress($slug: String!) {
+      lesson(slug: $slug) {
+        title
+        slug
+        path
+        completed
+      }
+    }
+  `
+  token = token || getAccessTokenFromCookie()
+  const graphQLClient = getGraphQLClient(token)
+  const variables = {
+    slug,
+  }
+  const {lesson} = await graphQLClient.request(query, variables)
+  return LessonProgressSchema.parse({lessonProgress: lesson})
+}
+
+export type LessonProgress = z.infer<typeof LessonProgressSchema>

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -178,7 +178,9 @@ export async function loadUserProgress(
     return {
       completionStats: {
         minutesWatched: user.minutes_watched,
-        completedCourseCount: user.courses_completed,
+        completedCourseCount: user.all_progress.data.filter(
+          (p: any) => p.is_complete,
+        ).length,
         completedLessonCount: user.lessons_completed,
       },
       progress: user.all_progress,

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -108,6 +108,7 @@ export async function loadUserProgress(
                   is_completed
                   completed_at
                   completed_lessons {
+                    id
                     title
                     slug
                     path
@@ -115,6 +116,7 @@ export async function loadUserProgress(
                 }
                 items {
                   ... on Lesson {
+                    id
                     title
                     slug
                     path
@@ -127,8 +129,10 @@ export async function loadUserProgress(
                 }
               }
               ... on Course {
+                id
                 title
                 lessons {
+                  id
                   title
                   slug
                   path
@@ -142,6 +146,7 @@ export async function loadUserProgress(
                   is_completed
                   completed_at
                   completed_lessons {
+                    id
                     title
                     slug
                     path

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -472,6 +472,16 @@ const Lesson: React.FC<LessonProps> = ({
   const markComplete = trpc.progress.markLessonComplete.useMutation({
     onSuccess: (data) => {
       trpcUtils.progress.forLesson.invalidate({slug: data.lesson_slug})
+
+      if (data?.collection_progress?.rate_url) {
+        console.debug('presenting opportunity to rate course', {
+          data,
+          video: data.lesson_slug,
+        })
+        console.debug('RATE')
+        console.log('sent rating')
+        send('RATE')
+      }
     },
     onError: (error) => {
       console.error(error)
@@ -479,7 +489,7 @@ const Lesson: React.FC<LessonProps> = ({
   })
 
   const markLessonComplete = () => {
-    markComplete.mutate({
+    markComplete.mutateAsync({
       lessonId: lesson.id,
       collectionId: lesson.collection?.id,
     })

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -218,8 +218,17 @@ const Lesson: React.FC<LessonProps> = ({
   const {data} = trpc.progress.forLesson.useQuery<LessonProgress>({
     slug: lesson.slug,
   })
+
+  const [lessonCompleted, setLessonCompleted] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    const completed = data?.lessonProgress?.completed
+    if (completed) {
+      setLessonCompleted(completed)
+    }
+  }, [data?.lessonProgress?.completed])
+
   const trpcUtils = trpc.useContext()
-  const lessonCompleted = data?.lessonProgress?.completed
 
   React.useEffect(() => {
     setPlayerVisible(
@@ -492,6 +501,8 @@ const Lesson: React.FC<LessonProps> = ({
       lessonId: lesson.id,
       collectionId: lesson.collection?.id,
     })
+
+    setLessonCompleted(true)
   }
 
   return (

--- a/src/pages/lessons/[slug].tsx
+++ b/src/pages/lessons/[slug].tsx
@@ -479,7 +479,6 @@ const Lesson: React.FC<LessonProps> = ({
           video: data.lesson_slug,
         })
         console.debug('RATE')
-        console.log('sent rating')
         send('RATE')
       }
     },

--- a/src/trpc/routers/progress.ts
+++ b/src/trpc/routers/progress.ts
@@ -2,8 +2,16 @@ import {router, baseProcedure} from '../trpc.server'
 import {z} from 'zod'
 import {ACCESS_TOKEN_KEY} from '../../utils/auth'
 import {loadLessonProgress, loadPlaylistProgress} from '../../lib/progress'
+import {loadUserCompletedCourses} from 'lib/users'
 
 export const progressRouter = router({
+  completedCourses: baseProcedure.query(async ({ctx}) => {
+    const token = ctx.req?.cookies[ACCESS_TOKEN_KEY]
+    if (!token) return []
+
+    const {completeCourses} = await loadUserCompletedCourses(token)
+    return completeCourses
+  }),
   forPlaylist: baseProcedure
     .input(
       z.object({
@@ -63,7 +71,6 @@ export const progressRouter = router({
         },
       ).then((res) => res.json())
 
-      console.log({res})
       return res
     }),
 })


### PR DESCRIPTION
Some learners were reporting that they couldn't mark a lesson complete after watching a lesson. This allows for manually marking a lesson as complete.

I also converted some react-query calls to trpc to consolidate data fetching and not have to manually track the keys we set for caching.

some minor issues I encountered: 
- manually marking a final lesson as complete does not trigger the end of course survey/rating. 
  - tried to use the lesson machine to trigger this but didn't have luck
  - this is the same behavior as rails had
- I attempt to invalidate the trpc cache for the progress that gets updated but it doesn't update right away (only after you navigate or click out of the screen)
- Hits component (search) does not cooperate with trpc. It might be SSR?

![completed lesson](https://user-images.githubusercontent.com/6188161/228663565-a3e908a2-af04-4912-83f2-551d52e3c855.png)
![uncompleted lesson](https://user-images.githubusercontent.com/6188161/228663568-a157d936-0edc-4c4b-8cb9-441f8bb8029a.png)


![check](https://media4.giphy.com/media/4T76vT3pi6wKTafS6G/giphy.gif?cid=1927fc1bp8vbr2qc8bgbiymxscnyrbkk6u4po1krs4e8bdc7&rid=giphy.gif&ct=g)