### PR TITLE
feat: touch up callout component

### DIFF
--- a/src/components/mdx/callout.js
+++ b/src/components/mdx/callout.js
@@ -1,13 +1,9 @@
-import React from 'react'
-
-const container = ''
-
-export default function Callout({children, className}) {
+export default function Callout({children, text, className}) {
   return (
     <div
-      className={`mx-auto my-3 w-full dark:bg-gray-800 bg-blue-100 border-l-4 overflow-hidden border-blue-900 dark:text-blue-200 text-blue-600 sm:px-8 px-4 py-3 rounded-sm`}
+      className={`leading-relaxed mx-auto my-3 w-full dark:bg-gray-800 bg-blue-100 border-l-4 border-blue-900  sm:px-8 px-4 py-6 rounded-sm font-small sm:text-lg text-base tracking-normal shadow-md ${className}`}
     >
-      {children}
+      {text ? text : children}
     </div>
   )
 }

--- a/src/components/mdx/callout.js
+++ b/src/components/mdx/callout.js
@@ -1,9 +1,0 @@
-export default function Callout({children, text, className}) {
-  return (
-    <div
-      className={`p-5 leading-relaxed mx-auto my-3 w-full dark:bg-gray-800 bg-blue-100 border-l-4 border-blue-900 sm:space-x-5 space-x-0 sm:space-y-0 space-y-5 items-center text-left shadow-sm rounded-lg overflow-hidden lg:text-lg sm:text-md ${className}`}
-    >
-      {text ? text : children}
-    </div>
-  )
-}

--- a/src/components/mdx/callout.js
+++ b/src/components/mdx/callout.js
@@ -1,7 +1,7 @@
 export default function Callout({children, text, className}) {
   return (
     <div
-      className={`leading-relaxed mx-auto my-3 w-full dark:bg-gray-800 bg-blue-100 border-l-4 border-blue-900  sm:px-8 px-4 py-6 rounded-sm font-small sm:text-lg text-base tracking-normal shadow-md ${className}`}
+      className={`p-5 leading-relaxed mx-auto my-3 w-full dark:bg-gray-800 bg-blue-100 border-l-4 border-blue-900 sm:space-x-5 space-x-0 sm:space-y-0 space-y-5 items-center text-left shadow-sm rounded-lg overflow-hidden lg:text-lg sm:text-md ${className}`}
     >
       {text ? text : children}
     </div>

--- a/src/components/mdx/callout.tsx
+++ b/src/components/mdx/callout.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import {twMerge} from 'tailwind-merge'
+
+type CalloutProps = {
+  text?: string
+  className?: string
+}
+
+const Callout: React.FC<React.PropsWithChildren<CalloutProps>> = ({
+  text,
+  className,
+  children,
+}) => {
+  return (
+    <div className="sm:mx-auto -mx-2">
+      <div
+        className={twMerge(
+          'sm:py-5 sm:px-5 py-3 px-5 leading-relaxed my-3 w-full dark:bg-gray-800 bg-blue-200/20 border-l-4 dark:border-blue-600 border-blue-500 items-center text-left shadow-sm sm:rounded-md overflow-hidden lg:text-lg sm:text-md',
+          className,
+        )}
+        aria-label="callout"
+      >
+        {text ? <p>{text}</p> : children}
+      </div>
+    </div>
+  )
+}
+
+export default Callout

--- a/src/components/mdx/code-block.tsx
+++ b/src/components/mdx/code-block.tsx
@@ -69,7 +69,7 @@ const CodeBlock: FunctionComponent<CodeBlockProps> = ({
   }
 
   return (
-    <div className="relative bg-gray-800 sm:mx-0 -mx-5 sm:rounded-md rounded-none mb-5 overflow-hidden">
+    <div className="relative bg-gray-800 sm:mx-0 -mx-2 sm:rounded-md rounded-none mb-5 overflow-hidden">
       {labeled && (
         <>
           <div className="sm:pb-3 pb-0 px-5 pt-5 text-white text-xs font-bold select-none pointer-events-none">
@@ -80,7 +80,7 @@ const CodeBlock: FunctionComponent<CodeBlockProps> = ({
         </>
       )}
       <div>
-        <style jsx>
+        <style>
           {`
             pre {
               font-size: 85% !important;

--- a/src/utils/remark/with-prose.js
+++ b/src/utils/remark/with-prose.js
@@ -34,7 +34,7 @@ module.exports.withProse = () => {
           {
             type: 'jsx',
             value:
-              '<div className="prose dark:prose-dark sm:prose-lg lg:prose-xl mt-5 max-w-none dark:prose-a:text-blue-300 prose-a:text-blue-500">',
+              '<div className="prose dark:prose-dark sm:prose-lg lg:prose-xl max-w-none dark:prose-a:text-blue-300 prose-a:text-blue-500">',
           },
           node,
           ...(i === tree.children.length - 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -20957,6 +20957,11 @@ table@^6.0.9:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
+tailwind-merge@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.12.0.tgz#747d09d64a25a4864150e8930f8e436866066cc8"
+  integrity sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==
+
 tailwindcss-autofill@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tailwindcss-autofill/-/tailwindcss-autofill-0.1.0.tgz#ca5872c866bea13ac45fd1610c7b48199156702f"


### PR DESCRIPTION
Made a few tweaks to the Callout component:

Added text prop for easier text rendering, falls back to children if not provided. I noticed that the callout had some whitespace due to "children" not just being the text, but the html that was created from the text when the markdown was compiled. 

I also cleaned up the component and added some additional text styling. 

## Old

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/518406/232126599-5a96d807-5656-40a0-8fa8-503b0cb064b7.png">
<img width="2560" alt="image" src="https://user-images.githubusercontent.com/518406/232126659-3f8ebac6-8784-4a88-aaea-cc91db022769.png">


## New

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/518406/232126712-8baedceb-723d-48fb-a5e6-3f006d1c8a90.png">
<img width="2560" alt="image" src="https://user-images.githubusercontent.com/518406/232126741-e05b8334-9867-4234-ba1e-9f2db4020f13.png">

