### PR TITLE
align titles and descriptions of sections to the left on curated pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "stripe": "^9.8.0",
     "superjson": "1.11.0",
     "swr": "^0.5.5",
+    "tailwind-merge": "^1.12.0",
     "tailwindcss": "^3.0.13",
     "tailwindcss-autofill": "^0.1.0",
     "tailwindcss-text-fill": "^0.1.2",

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -18,6 +18,7 @@ import {Textfit} from 'react-textfit'
 import analytics from 'utils/analytics'
 import Heading from './heading'
 import CheckIcon from 'components/icons/check'
+import {twMerge} from 'tailwind-merge'
 
 const VerticalResourceCard: React.FC<{
   resource: CardResource
@@ -54,7 +55,14 @@ const VerticalResourceCard: React.FC<{
       instructor={resource?.instructor?.name}
       tag={resource.tag?.name}
     >
-      <Card {...props} resource={resource} className={className}>
+      <Card
+        {...props}
+        resource={resource}
+        className={twMerge(
+          'rounded-md aspect-w-3 aspect-h-4 w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50',
+          className,
+        )}
+      >
         {resource.background && (
           <Image
             src={resource.background}

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -12,6 +12,7 @@ import {CARD_TYPES} from 'components/search/curated/curated-essential'
 import {useRouter} from 'next/router'
 import {useViewer} from 'context/viewer-context'
 import {loadUserCompletedCourses} from 'lib/users'
+import {twMerge} from 'tailwind-merge'
 
 const useUserCompletedCourses = (viewerId: number) => {
   return useQuery(['completeCourses'], async () => {
@@ -25,6 +26,102 @@ const useUserCompletedCourses = (viewerId: number) => {
 type CuratedTopicProps = {
   topicData: any
   topic: any
+}
+
+const DynamicCardGrid = ({
+  section,
+  completedCoursesIds,
+  location,
+  className,
+}: {
+  section: any
+  completedCoursesIds: string[]
+  location: string
+  className?: string
+}) => {
+  return (
+    <Grid
+      className={twMerge(
+        'grid grid-cols-2 lg:grid-cols-4 md:grid-cols-3 sm:gap-3 gap-2',
+        className,
+      )}
+    >
+      {section.resources.map((resource: any, i: number) => {
+        switch (section.resources.length) {
+          case 2:
+            return (
+              <HorizontalResourceCard
+                className="col-span-2"
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            )
+          case 3:
+            return i === 0 ? (
+              <HorizontalResourceCard
+                className="col-span-2"
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            ) : (
+              <VerticalResourceCard
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            )
+          case 6:
+            return i === 0 || i === 1 ? (
+              <HorizontalResourceCard
+                className="col-span-2"
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            ) : (
+              <VerticalResourceCard
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            )
+          case 7:
+            return i === 0 ? (
+              <HorizontalResourceCard
+                className="col-span-2"
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            ) : (
+              <VerticalResourceCard
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            )
+          default:
+            return (
+              <VerticalResourceCard
+                key={resource.title}
+                resource={resource}
+                location={location}
+                completedCoursesIds={completedCoursesIds}
+              />
+            )
+        }
+      })}
+    </Grid>
+  )
 }
 
 const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
@@ -131,19 +228,27 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
         )}
         <div className="sm:px-5 px-3 sm:pt-16 pt-8">
           {!isEmpty(sections) &&
-            sections.map((section: any) => {
-              return (
-                <section className="pb-16" key={section.title}>
-                  {!section.image && !section.description ? (
-                    // simple section
-                    <div className="flex w-full pb-6 items-center justify-start">
-                      <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight sm:px-7 px-5">
-                        {section.title}
-                      </h2>
-                    </div>
-                  ) : (
+            sections.map((section: any, i: number) => {
+              switch (true) {
+                case !section.image && !section.description:
+                  return (
+                    <section className="pb-16" key={section.title}>
+                      <div className="flex w-full pb-6 items-center justify-start">
+                        <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+                          {section.title}
+                        </h2>
+                      </div>
+                      <DynamicCardGrid
+                        section={section}
+                        completedCoursesIds={completedCoursesIds}
+                        location={location}
+                      />
+                    </section>
+                  )
+                case section.resources.length === 2:
+                  return (
                     // section with image and description
-                    <div className="flex md:flex-row flex-col md:items-start items-center justify-start w-full mb-5 pb-8 md:space-x-10 sm:px-7 px-5">
+                    <div className="flex md:flex-row flex-col md:items-start items-center justify-start w-full mb-5 pb-8 md:space-x-10">
                       {section.image && (
                         <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
                           <Image
@@ -156,94 +261,125 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           />
                         </div>
                       )}
-                      <div>
-                        <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
-                          {section.title}
-                        </h2>
-                        {section.description && (
-                          <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700">
-                            {section.description}
-                          </ReactMarkdown>
-                        )}
+                      <div className="grid sm:grid-cols-4 gap-4 ">
+                        <div
+                          className={`col-span-2  ${cx({
+                            'sm:order-last': i % 2 !== 0,
+                          })}`}
+                        >
+                          <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
+                            {section.title}
+                          </h2>
+                          {section.description && (
+                            <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700 dark:prose-sm">
+                              {section.description}
+                            </ReactMarkdown>
+                          )}
+                        </div>
+                        {section.resources.map((resource: any) => {
+                          return (
+                            <div className="sm:h-80 self-center">
+                              <VerticalResourceCard
+                                key={resource.title}
+                                resource={resource}
+                                location={location}
+                                completedCoursesIds={completedCoursesIds}
+                              />
+                            </div>
+                          )
+                        })}
                       </div>
                     </div>
-                  )}
-                  <Grid className="grid grid-cols-2 lg:grid-cols-4 md:grid-cols-3 sm:gap-3 gap-2">
-                    {section.resources.map((resource: any, i: number) => {
-                      switch (section.resources.length) {
-                        case 2:
-                          return (
-                            <HorizontalResourceCard
-                              className="col-span-2"
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          )
-                        case 3:
-                          return i === 0 ? (
-                            <HorizontalResourceCard
-                              className="col-span-2"
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          ) : (
-                            <VerticalResourceCard
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          )
-                        case 6:
-                          return i === 0 || i === 1 ? (
-                            <HorizontalResourceCard
-                              className="col-span-2"
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          ) : (
-                            <VerticalResourceCard
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          )
-                        case 7:
-                          return i === 0 ? (
-                            <HorizontalResourceCard
-                              className="col-span-2"
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          ) : (
-                            <VerticalResourceCard
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          )
-                        default:
-                          return (
-                            <VerticalResourceCard
-                              key={resource.title}
-                              resource={resource}
-                              location={location}
-                              completedCoursesIds={completedCoursesIds}
-                            />
-                          )
-                      }
-                    })}
-                  </Grid>
+                  )
+                case section.resources.length === 4 && !section.image:
+                  let primarySections = section.resources.slice(0, 2)
+                  let secondarySections = section.resources.slice(2, 4)
+
+                  return (
+                    <div>
+                      <div className="flex md:flex-row flex-col md:items-start items-center justify-start w-full mb-5 pb-8 md:space-x-10">
+                        <div className="grid lg:grid-cols-4 gap-4">
+                          <div className="col-span-2">
+                            <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
+                              {section.title}
+                            </h2>
+                            {section.description && (
+                              <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700 dark:prose-sm">
+                                {section.description}
+                              </ReactMarkdown>
+                            )}
+                          </div>
+                          {secondarySections.map((resource: any) => {
+                            return (
+                              <div className="hidden lg:block">
+                                <VerticalResourceCard
+                                  key={resource.title}
+                                  resource={resource}
+                                  location={location}
+                                  completedCoursesIds={completedCoursesIds}
+                                />
+                              </div>
+                            )
+                          })}
+                          {primarySections.map((resource: any) => {
+                            return (
+                              <HorizontalResourceCard
+                                className="col-span-2  hidden lg:block"
+                                key={resource.title}
+                                resource={resource}
+                                location={location}
+                                completedCoursesIds={completedCoursesIds}
+                              />
+                            )
+                          })}
+                          {section.resources.map((resource: any) => {
+                            return (
+                              <VerticalResourceCard
+                                className="lg:hidden"
+                                key={resource.title}
+                                resource={resource}
+                                location={location}
+                                completedCoursesIds={completedCoursesIds}
+                              />
+                            )
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  )
+              }
+
+              return (
+                <section className="pb-16" key={section.title}>
+                  <div className="flex md:flex-row flex-col md:items-start items-center justify-start w-full mb-5 pb-8 md:space-x-10 sm:px-7 px-5">
+                    {section.image && (
+                      <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
+                        <Image
+                          aria-hidden
+                          src={section.image}
+                          quality={100}
+                          width={240}
+                          height={240}
+                          alt=""
+                        />
+                      </div>
+                    )}
+                    <div>
+                      <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
+                        {section.title}
+                      </h2>
+                      {section.description && (
+                        <ReactMarkdown className="prose sm:prose prose-sm dark:prose-dark dark:text-gray-300 text-gray-700 dark:prose-sm">
+                          {section.description}
+                        </ReactMarkdown>
+                      )}
+                    </div>
+                  </div>
+                  <DynamicCardGrid
+                    section={section}
+                    completedCoursesIds={completedCoursesIds}
+                    location={location}
+                  />
                 </section>
               )
             })}

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -14,15 +14,6 @@ import {loadUserCompletedCourses} from 'lib/users'
 import {twMerge} from 'tailwind-merge'
 import {trpc} from 'trpc/trpc.client'
 
-const useUserCompletedCourses = (viewerId: number) => {
-  return useQuery(['completeCourses'], async () => {
-    if (viewerId) {
-      const {completeCourses} = await loadUserCompletedCourses()
-      return completeCourses
-    }
-  })
-}
-
 type CuratedTopicProps = {
   topicData: any
   topic: any

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -261,10 +261,10 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           />
                         </div>
                       )}
-                      <div className="grid sm:grid-cols-4 gap-4 ">
+                      <div className="grid md:grid-cols-4 gap-4 ">
                         <div
                           className={`col-span-2  ${cx({
-                            'sm:order-last': i % 2 !== 0,
+                            'md:order-last': i % 2 !== 0,
                           })}`}
                         >
                           <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
@@ -278,7 +278,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                         </div>
                         {section.resources.map((resource: any) => {
                           return (
-                            <div className="sm:h-80 self-center">
+                            <div className="self-center">
                               <VerticalResourceCard
                                 key={resource.title}
                                 resource={resource}
@@ -311,7 +311,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                           </div>
                           {secondarySections.map((resource: any) => {
                             return (
-                              <div className="hidden lg:block">
+                              <div className="hidden lg:block self-center">
                                 <VerticalResourceCard
                                   key={resource.title}
                                   resource={resource}

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -91,7 +91,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
       </header>
       <div>
         {!isEmpty(levels) && (
-          <div className="relative sm:pt-16 pt-8 sm:pb-28 pb-10">
+          <div className="relative sm:pt-16 pt-8 sm:pb-12 pb-2">
             <p className="sm:text-sm text-xs font-mono text-medium tracking-wide uppercase opacity-80 sm:pl-12 sm:text-left text-center sm:pb-0 pb-8">
               {levels.subTitle}
             </p>
@@ -129,21 +129,21 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
             </div>
           </div>
         )}
-        <div className="sm:px-5 px-3">
+        <div className="sm:px-5 px-3 sm:pt-16 pt-8">
           {!isEmpty(sections) &&
             sections.map((section: any) => {
               return (
                 <section className="pb-16" key={section.title}>
                   {!section.image && !section.description ? (
                     // simple section
-                    <div className="flex w-full pb-6 items-center justify-between">
-                      <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
+                    <div className="flex w-full pb-6 items-center justify-start">
+                      <h2 className="lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight sm:px-7 px-5">
                         {section.title}
                       </h2>
                     </div>
                   ) : (
                     // section with image and description
-                    <div className="flex md:flex-row flex-col md:items-start items-center justify-center w-full mb-5 pb-8 md:space-x-10">
+                    <div className="flex md:flex-row flex-col md:items-start items-center justify-start w-full mb-5 pb-8 md:space-x-10 sm:px-7 px-5">
                       {section.image && (
                         <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
                           <Image


### PR DESCRIPTION
When there is no image present for an article, it looks a little off to have the titles and descriptions centered when the topic title and description is left aligned. 

This also adds a little padding to the top of the sections so theres sufficient space when the `Levels` component isn't present.

# before
![In-Depth Redux Tutorials for 2023  egghead io](https://user-images.githubusercontent.com/6188161/233161288-8267b342-8333-4ba5-9179-37707d63ad76.png)

# after
![In-Depth Redux Tutorials for 2023  egghead io](https://user-images.githubusercontent.com/6188161/233500696-191063bd-27a4-409a-8cb0-7f599e589da3.png)
![In-Depth Redux Tutorials for 2023  egghead io](https://user-images.githubusercontent.com/6188161/233500720-556f0082-c3a2-4d81-8c27-2a02fde6bf7c.png)
