### PR TITLE
[fixes EGG-192]: Convert article resource image on cards to cover instead of contain

### DIFF
--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -154,7 +154,7 @@ const PreviewImage: React.FC<{title: string; image: any; name: string}> = ({
       case 'talk':
         return 80
       case 'article':
-        return 300
+        return 500
       default:
         return 200
     }
@@ -171,8 +171,8 @@ const PreviewImage: React.FC<{title: string; image: any; name: string}> = ({
       <Image
         aria-hidden
         src={get(image, 'src', image)}
-        width={name === 'article' ? 500 : getSize(name)}
-        height={name === 'article' ? 500 : getSize(name)}
+        width={getSize(name)}
+        height={getSize(name)}
         quality={100}
         alt=""
       />

--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -54,8 +54,12 @@ const HorizontalResourceCard: React.FC<{
       tag={resource.tag?.name}
     >
       <Card {...props} resource={resource} className={defaultClassName}>
-        <CardContent className="grid grid-cols-8 gap-5 items-center px-5 py-2">
-          <CardHeader className="col-span-3 flex items-center justify-center">
+        <CardContent className="grid grid-cols-8 gap-5   items-center px-5 py-2">
+          <CardHeader
+            className={`col-span-3 flex items-center justify-center ${cx({
+              '-ml-32 -my-64': resource.name === 'article',
+            })}`}
+          >
             <PreviewImage
               name={resource.name}
               image={resource.image}
@@ -149,6 +153,8 @@ const PreviewImage: React.FC<{title: string; image: any; name: string}> = ({
         return 40
       case 'talk':
         return 80
+      case 'article':
+        return 300
       default:
         return 200
     }
@@ -159,13 +165,14 @@ const PreviewImage: React.FC<{title: string; image: any; name: string}> = ({
         'max-w-[40px]': name === 'lesson',
         'max-w-[80px]': name === 'talk',
         'xl:max-w-[200px] sm:max-w-[150px] max-w-[100px]': name === 'course',
+        'object-cover': name === 'article',
       })}`}
     >
       <Image
         aria-hidden
         src={get(image, 'src', image)}
-        width={getSize(name)}
-        height={getSize(name)}
+        width={name === 'article' ? 500 : getSize(name)}
+        height={name === 'article' ? 500 : getSize(name)}
         quality={100}
         alt=""
       />

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -177,7 +177,6 @@ const PreviewImage: React.FC<{
   small?: boolean
   resourceType: string
 }> = ({title, image, small, resourceType}) => {
-  console.log({resourceType})
   if (!image) return null
 
   return (

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -19,6 +19,7 @@ import analytics from 'utils/analytics'
 import Heading from './heading'
 import CheckIcon from 'components/icons/check'
 import {twMerge} from 'tailwind-merge'
+import cx from 'classnames'
 
 const VerticalResourceCard: React.FC<{
   resource: CardResource
@@ -73,11 +74,20 @@ const VerticalResourceCard: React.FC<{
           />
         )}
         <CardContent className="grid grid-rows-6 xl:p-5 p-2 pt-5">
-          <CardHeader className={`row-span-3 relative `}>
+          <CardHeader
+            className={`
+            row-span-3 
+            relative 
+            ${cx({
+              '-mx-5 -mt-5': resource.name === 'article',
+            })}
+            `}
+          >
             <PreviewImage
               small={small}
               image={resource.image}
               title={resource.title}
+              resourceType={resource.name}
             />
           </CardHeader>
           <CardMeta
@@ -161,18 +171,20 @@ export const ResourceLink: React.FC<{
   </Link>
 )
 
-const PreviewImage: React.FC<{title: string; image: any; small?: boolean}> = ({
-  title,
-  image,
-  small,
-}) => {
+const PreviewImage: React.FC<{
+  title: string
+  image: any
+  small?: boolean
+  resourceType: string
+}> = ({title, image, small, resourceType}) => {
+  console.log({resourceType})
   if (!image) return null
 
   return (
     <Image
       aria-hidden
       src={get(image, 'src', image)}
-      objectFit="contain"
+      objectFit={resourceType === 'article' ? 'cover' : 'contain'}
       layout="fill"
       quality={100}
       alt=""

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -251,7 +251,11 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                         </div>
                       )}
                       <div className="grid md:grid-cols-4 gap-4 ">
-                        <div className={`col-span-2  `}>
+                        <div
+                          className={`col-span-2  ${cx({
+                            'md:order-last': i % 2 !== 0,
+                          })}`}
+                        >
                           <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
                             {section.title}
                           </h2>

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -251,11 +251,7 @@ const CuratedTopic: React.FC<CuratedTopicProps> = ({topic, topicData}) => {
                         </div>
                       )}
                       <div className="grid md:grid-cols-4 gap-4 ">
-                        <div
-                          className={`col-span-2  ${cx({
-                            'md:order-last': i % 2 !== 0,
-                          })}`}
-                        >
+                        <div className={`col-span-2  `}>
                           <h2 className="w-full lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight pb-4">
                             {section.title}
                           </h2>


### PR DESCRIPTION
Our cards don't support article images very well, they assume that the image is square and small (like podcast and course resources) where that is not the case.

The result is the images get contorted and look out of place, see down below.

## Before
![desktop - before showing square images with awkward padding](https://user-images.githubusercontent.com/6188161/234072758-bf3b32b0-68b3-40a5-865c-d125aecae63b.png)

## After
![desktop after showing image covering top and left side of cards](https://user-images.githubusercontent.com/6188161/234073355-8b830bc2-6b18-4175-a902-e176f67c6cf9.png)
![mobile after showing image covering top and left side of cards](https://user-images.githubusercontent.com/6188161/234073036-88a34b01-ca89-465f-b602-a395051b7d54.png)

![cats chillin](https://media.giphy.com/media/GwGXoeb0gm7sc/giphy.gif)