### PR TITLE
fix: remove default card styles from props

### DIFF
--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -33,7 +33,7 @@ const VerticalResourceCard: React.FC<{
   children,
   resource,
   location,
-  className = 'rounded-md aspect-w-3 aspect-h-4 w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50',
+  className,
   describe = false,
   small = false,
   as,


### PR DESCRIPTION
Now that we are actually applying the className prop, these default classes were being applied to every card because in most cases we are not passing any extra classes.

This removes these classes so cards can go back to normal.

![fixed](https://media.giphy.com/media/lVBtp4SRW6rvDHf1b6/giphy-downsized.gif)
## Before
![before](https://user-images.githubusercontent.com/6188161/234348920-89ebfa1b-3063-41f9-a1c9-332c85766580.png)

## After
![after](https://user-images.githubusercontent.com/6188161/234348825-c0c59748-df2d-461f-89ab-413b3206fb85.png)
