### PR TITLE
increase default container padding to 1rem

### DIFF
--- a/src/components/mdx/callout.tsx
+++ b/src/components/mdx/callout.tsx
@@ -12,7 +12,7 @@ const Callout: React.FC<React.PropsWithChildren<CalloutProps>> = ({
   children,
 }) => {
   return (
-    <div className="sm:mx-auto -mx-2">
+    <div className="sm:mx-auto -mx-4">
       <div
         className={twMerge(
           'sm:py-5 sm:px-5 py-3 px-5 leading-relaxed my-3 w-full dark:bg-gray-800 bg-blue-200/20 border-l-4 dark:border-blue-600 border-blue-500 items-center text-left shadow-sm sm:rounded-md overflow-hidden lg:text-lg sm:text-md',

--- a/src/components/mdx/code-block.tsx
+++ b/src/components/mdx/code-block.tsx
@@ -69,7 +69,7 @@ const CodeBlock: FunctionComponent<CodeBlockProps> = ({
   }
 
   return (
-    <div className="relative bg-gray-800 sm:mx-0 -mx-2 sm:rounded-md rounded-none mb-5 overflow-hidden">
+    <div className="relative bg-gray-800 sm:mx-0 -mx-4 sm:rounded-md rounded-none mb-5 overflow-hidden">
       {labeled && (
         <>
           <div className="sm:pb-3 pb-0 px-5 pt-5 text-white text-xs font-bold select-none pointer-events-none">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
     container: {
       center: true,
       padding: {
-        DEFAULT: '0.5rem',
+        DEFAULT: '1rem',
         md: '1.5rem',
       },
     },


### PR DESCRIPTION
Prose text felt too crowded with the boarder of the screen. This increases the padding to 1rem/8px. Previously, it was 0.5rem/4px.

## Before
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/518406/234718002-d7671c0f-3e3d-45f9-a15b-44f7cd3e025a.png">
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/518406/234718079-1781b6df-4f25-40d9-891f-640aba908e72.png">
 

## After
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/518406/234718121-a4321520-7fe5-48a4-88d1-49827ea5686f.png">
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/518406/234718237-8587ffe0-b429-4823-b8ad-a6133fc748c4.png">
