### PR TITLE
fix headings and add heading ids

### DIFF
--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -10,31 +10,37 @@ export default ({children}) => (
 
 ## Billing
 
-#### What payment methods are accepted?
+<h3 id="payment-methods"> What payment methods are accepted?</h3>
 
 Currently, we only accept payment via credit card for individual memberships and teams consisting of less than 30 members.
 
 We do not accept PayPal.
 
-#### Can I pay through invoice?
+<h3 id="pay-invoice"> Can I pay through invoice?</h3>
 
 If you are purchasing for a team of 30+ members, please contact us at support@egghead.io for more information on invoicing.
 
-#### Do you have payment plans available for an annual memberships?
+<h3 id="payment-plans">
+  {' '}
+  Do you have payment plans available for an annual memberships?
+</h3>
 
 We don’t offer payment plans. If you’re able, you can start out with a monthly or quarterly plan and then upgrade to an annual membership in the future.
 
-#### Where can I find my invoices?
+<h3 id="find-invoice"> Where can I find my invoices?</h3>
 
 Once you’re logged in, you can view and download all your invoices directly from here: [https://egghead.io/invoices](https://egghead.io/invoices)
 
 From there, you can also add any required information to the "Prepared for" section of each invoice.
 
-#### Renewal cost from year-to-year
+<h3 id="renewal-cost"> Renewal cost from year-to-year</h3>
 
 Your membership price will be locked in at the time you purchase, and will continue to renew at that price each billing cycle unless/until you cancel it.
 
-#### Can I get a refund for a new membership or a recent renewal charge?
+<h3 id="refund-recent-charge">
+  {' '}
+  Can I get a refund for a new membership or a recent renewal charge?
+</h3>
 
 Please contact **[support@egghead.io](mailto:support@egghead.io)** to request a refund.
 
@@ -46,11 +52,11 @@ If you haven’t received your refund after 10 business days, first check your b
 
 ## Membership
 
-#### Will my membership automatically renew?
+<h3 id="auto-renew"> Will my membership automatically renew?</h3>
 
 Yes, all memberships will automatically renew at the end of each billing period unless they are canceled before the renewal date.
 
-#### Can I cancel my membership?
+<h3 id="cancel-membership">Can I cancel my membership?</h3>
 
 Yes, you can cancel your membership at any time before your next renewal date to prevent it from automatically renewing. When you cancel, your membership will remain active until your renewal date but will not renew at that time.
 
@@ -59,62 +65,65 @@ If you’d like to cancel, you can do that from your account profile by followin
 1. Click the "Manage Your Membership" button to open your Stripe billing screen
 2. Click the "Cancel Plan" button to the right of your current plan
 
-#### Is parity pricing available?
+<h3 id="ppp"> Is parity pricing available?</h3>
 
 If we offer parity pricing in your area, it will automatically show up on the pricing page. You'll see the discount offer under the standard pricing area, with the discount specific to your country listed. You must select the offer to have it applied at checkout. Please note, this is automated based on the IP address of the computer you are using to make the purchase.
 
-#### Are there any limitations with parity pricing?
+<h3 id="ppp-limatations"> Are there any limitations with parity pricing?</h3>
 
 Yes, the specific terms and conditions are listed with the parity discount offer that is displayed on the pricing page.
 
-#### Do you offer gift memberships?
+<h3 id="gifts"> Do you offer gift memberships?</h3>
 
 No.
 
-#### Do you offer any discounts?
+<h3 id="discounts"> Do you offer any discounts?</h3>
 
 We provide parity pricing discounts for some regions, but we don’t offer any other form of discount. However, we do have sale events periodically throughout the year where you can purchase a membership at a discounted price.
 
-#### Are there free courses available?
+<h3 id=""> Are there free courses available?</h3>
 
 Yes, there are some courses that are free to access for all. They are designated as a “Community Resource,” which means the instructor of the lesson requested it to be open to the public. You can use the [search page](https://egghead.io/q) to filter out free courses.
 
 ## Team Plans
 
-#### Do you offer team plans?
+<h3 id="team-plans"> Do you offer team plans?</h3>
 
-Yes, you can purchase a team plan from the pricing page. Just select the number of seats required before you proceed to purchase.
+Yes, you can purchase a team plan from the pricing page. Just select the number of seats required before you proceed to purchase. Learn more about team plans [here](https://egghead.io/egghead-for-teams).
 
-#### What is included with a team plan?
+<h3 id="team-plan-features"> What is included with a team plan?</h3>
 
 A team plan allows you to have a single account with multiple team members and one account administrator. With a team plan, you can switch members in and out of the team throughout the year as many times as you'd like, as well as increase/decrease the total size of your team at any time.
 
-#### Is there a minimum/maximum number of members required for a team plan?
+<h3 id="team-plan-reqs">
+  {' '}
+  Is there a minimum/maximum number of members required for a team plan?
+</h3>
 
 No, team plans can consist of a single member or as many members as needed. We do offer bulk discounts based on the team size. Those are calculated automatically, and you can see the discount you’ll receive by entering the number of seats needed on the pricing page.
 
-#### Can I change the team administrator?
+<h3 id="change-team-admin"> Can I change the team administrator?</h3>
 
 Yes, you can change the team administrator at any time from your team management page.
 
-#### How do I add/remove members?
+<h3 id="add-remove-team-member"> How do I add/remove members?</h3>
 
 You can manage your team from the team management page in your administrator account. You can remove team members directly but will need to send an invitation to add new team members.
 
 ## Account
 
-#### How do I log in?
+<h3 id="log-in"> How do I log in?</h3>
 
 You can log in by requesting a login link from the [Sign In page](https://egghead.io/login). We also allow GitHub authentication, if you'd prefer an alternative option. You can set that up from your account profile.
 
-#### Can I use GitHub to log in?
+<h3 id="log-in-with-github"> Can I use GitHub to log in?</h3>
 
 Yes, you can set up GitHub authentication from your account profile by following the steps below:
 
 1. Click your name and avatar in the upper right corner of any page to open your account profile
 2. Click the "Connect your GitHub account" button under the "Connect to GitHub" section of your profile
 
-#### Can I delete my account?
+<h3 id="delete-account"> Can I delete my account?</h3>
 
 You can delete your account from the old version of the website - it still provides access to functionality that is currently not present on the new site. Please follow the steps below:
 
@@ -124,7 +133,7 @@ You can delete your account from the old version of the website - it still provi
 4. Click the "Edit Profile" tab
 5. Click "Delete Account" in the bottom right corner of the edit profile screen
 
-#### Can I change my account email address?
+<h3 id="change-email"> Can I change my account email address?</h3>
 
 Yes, you can change your account email address from your profile by following the steps below:
 

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -81,7 +81,7 @@ No.
 
 We provide parity pricing discounts for some regions, but we don’t offer any other form of discount. However, we do have sale events periodically throughout the year where you can purchase a membership at a discounted price.
 
-<h3 id=""> Are there free courses available?</h3>
+<h3 id="free-courses"> Are there free courses available?</h3>
 
 Yes, there are some courses that are free to access for all. They are designated as a “Community Resource,” which means the instructor of the lesson requested it to be open to the public. You can use the [search page](https://egghead.io/q) to filter out free courses.
 


### PR DESCRIPTION
The FAQ page has improper heading levels that go from h2 directly to h4. This updates headings to be h3 and adds heading ids so we can link directly to them from support

![image](https://user-images.githubusercontent.com/6188161/234942062-f219772e-1e86-43f8-85dd-b95473a6f306.png)


![headings](https://media.giphy.com/media/m9eG1qVjvN56H0MXt8/giphy-downsized.gif)