### PR TITLE
[fixes egg-200]: Display different components based on sanity property on Home page

### DIFF
--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -25,7 +25,7 @@ const HorizontalResourceCard: React.FC<{
   location?: string
   describe?: boolean
   className?: string
-  completedCoursesIds?: string[]
+  completedCoursesIds?: number[]
 }> = ({
   children,
   resource,

--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -40,7 +40,7 @@ const HorizontalResourceCard: React.FC<{
   const isCourseCompleted =
     !isEmpty(completedCoursesIds) &&
     externalId &&
-    completedCoursesIds?.some((courseId: string) => courseId === externalId)
+    completedCoursesIds?.some((courseId: number) => courseId === externalId)
 
   const defaultClassName =
     'rounded-md aspect-w-4 aspect-h-2 w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50'
@@ -49,7 +49,7 @@ const HorizontalResourceCard: React.FC<{
       path={(resource.path || resource.url) as string}
       location={location as string}
       className={className}
-      resource_type={resource.name}
+      resource_type={resource.name || ''}
       instructor={resource.instructor?.name}
       tag={resource.tag?.name}
     >
@@ -61,9 +61,9 @@ const HorizontalResourceCard: React.FC<{
             })}`}
           >
             <PreviewImage
-              name={resource.name}
+              name={resource.name || ''}
               image={resource.image}
-              title={resource.title}
+              title={resource.title || ''}
             />
           </CardHeader>
           <CardBody className="col-span-5">

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -28,7 +28,7 @@ const VerticalResourceCard: React.FC<{
   className?: string
   small?: boolean
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'p'
-  completedCoursesIds?: string[]
+  completedCoursesIds?: number[]
 }> = ({
   children,
   resource,

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -45,14 +45,14 @@ const VerticalResourceCard: React.FC<{
   const isCourseCompleted =
     !isEmpty(completedCoursesIds) &&
     externalId &&
-    completedCoursesIds?.some((courseId: string) => courseId === externalId)
+    completedCoursesIds?.some((courseId: number) => courseId === externalId)
 
   return (
     <ResourceLink
       path={(resource.path || resource.url) as string}
       location={location as string}
       target={resource.url ? '_blank' : undefined}
-      resource_type={resource.name}
+      resource_type={resource.name || ''}
       instructor={resource?.instructor?.name}
       tag={resource.tag?.name}
       className={className}
@@ -84,8 +84,8 @@ const VerticalResourceCard: React.FC<{
             <PreviewImage
               small={small}
               image={resource.image}
-              title={resource.title}
-              resourceType={resource.name}
+              title={resource.title || ''}
+              resourceType={resource.name || ''}
             />
           </CardHeader>
           <CardMeta

--- a/src/components/pages/home/egghead-for-teams-cta.tsx
+++ b/src/components/pages/home/egghead-for-teams-cta.tsx
@@ -2,11 +2,23 @@ import * as React from 'react'
 import {FunctionComponent} from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import analytics from 'utils/analytics'
 
-const EggheadForTeamsCta: FunctionComponent = () => {
+const EggheadForTeamsCta: FunctionComponent<{location: string}> = ({
+  location,
+}) => {
   return (
     <section className=" mb-16">
-      <Link href="/egghead-for-teams">
+      <Link
+        href="/egghead-for-teams"
+        onClick={() =>
+          analytics.events.activityCtaClick(
+            'team',
+            location,
+            '/egghead-for-teams',
+          )
+        }
+      >
         <div className="min-w-[24em] w-fit mx-auto cursor-pointer">
           <div className="dark:bg-gray-500 bg-slate-200 rounded p-[1px] transition-all hover:animate-gradient-xy hover:bg-gradient-to-br hover:from-amber-400 hover:via-amber-200 hover:to-yellow-400 ">
             <div className="relative justify-items-center md:w-[46rem] shrink-0 grid grid-cols-1 md:grid-cols-6 rounded gap-4 p-8 dark:bg-gray-800 bg-white">

--- a/src/components/pages/home/egghead-for-teams-cta.tsx
+++ b/src/components/pages/home/egghead-for-teams-cta.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import {FunctionComponent} from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+
+const EggheadForTeamsCta: FunctionComponent = () => {
+  return (
+    <section className=" mb-16">
+      <Link href="/egghead-for-teams">
+        <div className="min-w-[24em] w-fit mx-auto cursor-pointer">
+          <div className="dark:bg-gray-500 bg-slate-200 rounded p-[1px] transition-all hover:animate-gradient-xy hover:bg-gradient-to-br hover:from-amber-400 hover:via-amber-200 hover:to-yellow-400 ">
+            <div className="relative justify-items-center md:w-[46rem] shrink-0 grid grid-cols-1 md:grid-cols-6 rounded gap-4 p-8 dark:bg-gray-800 bg-white">
+              <div className="absolute -right-2 -top-2 h-32 w-32 overflow-hidden rounded-sm">
+                <div className="absolute top-0 left-[14px] h-2 w-2 bg-amber-500 after:-z-10"></div>
+                <div className="absolute right-0 bottom-[14px] h-2 w-2 bg-amber-500"></div>
+                <a
+                  className="absolute bottom-16 -right-12 rotate-45  w-[141.42%] rounded-sm px-5 py-2 
+              text-sm font-semibold uppercase tracking-wide text-center shadow-lg text-amber-800
+              bg-gradient-to-br from-amber-300 via-amber-100 to-yellow-300 animate-gradient-xy hover:from-amber-400 hover:via-amber-200 hover:to-yellow-400"
+                >
+                  For Teams
+                </a>
+              </div>
+              <div className="flex-shrink-0 relative flex items-center justify-center w-[240px] lg:w-[300px] xl:w-[360px] col-span-2">
+                <Image
+                  alt="eggos climbing mountain self-center"
+                  className="hover:scale-95 transition-all"
+                  height={237}
+                  width={226}
+                  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1682701917/eggodex/egh_climbers.png"
+                />
+              </div>
+              <div className="flex flex-col shrink-0 md:col-span-4 space-y-4 md:w-[42ch] p-4">
+                <h2 className="text-lg lg:text-2xl sm:text-xl font-bold">
+                  egghead for Teams
+                </h2>
+                <p className=" text-amber-600 dark:text-amber-300 font-medium hidden md:block">
+                  Keeping your team up to date and consistent with the
+                  application of frameworks, patterns, and best practices is an
+                  ongoing and extreme challenge for any organization.
+                </p>
+                <ul className="grid md:grid-cols-4 gap-2 my-8">
+                  <li className="md:col-span-2">
+                    <span className="text-amber-300 font-bold">✓</span> high
+                    quality product development
+                  </li>
+                  <li className="md:col-span-2">
+                    <span className="text-amber-300 font-bold">✓</span>{' '}
+                    understanding around "how we got here"
+                  </li>
+                  <li className="md:col-span-2">
+                    <span className="text-amber-300 font-bold">✓</span> shared
+                    knowledge and understanding of tools
+                  </li>
+                  <li className="md:col-span-2">
+                    <span className="text-amber-300 font-bold">✓</span>{' '}
+                    alignment on best practices
+                  </li>
+                </ul>
+                <button className="mt-4 bg-amber-300 text-amber-800 hover:bg-yellow-300 py-3 px-4 rounded-xl font-bold bg-gradient-to-br from-amber-300 via-amber-100 to-yellow-300 animate-gradient-xy hover:from-amber-400 hover:via-amber-200 hover:to-yellow-400">
+                  Level Up Your Team
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </section>
+  )
+}
+
+export default EggheadForTeamsCta

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -19,7 +19,7 @@ const Home: React.FC<any> = ({
   const router = useRouter()
   const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
   const completedCoursesIds = completeCourseData?.map(
-    (course): number => course.collection.id,
+    (course: any): number => course.collection.id,
   )
 
   React.useEffect(() => {

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -1,27 +1,26 @@
 import * as React from 'react'
 import {useRouter} from 'next/router'
-import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
-import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
 import Search from 'components/pages/home/search'
-import Topics from 'components/pages/home/topics'
-import ReactMarkdown from 'react-markdown'
-import {CardResource} from 'types'
-import Grid from 'components/grid'
-import Image from 'next/image'
-import Link from 'next/link'
 import Jumbotron from 'components/pages/home/jumbotron'
+import SanitySections from 'components/pages/home/sanity-sections'
 import toast, {Toaster} from 'react-hot-toast'
-import analytics from 'utils/analytics'
-import {useViewer} from 'context/viewer-context'
-import {isEmpty} from 'lodash'
 import {trpc} from 'trpc/trpc.client'
+import {SanitySectionType, CuratedHomePageDataType} from 'pages/learn'
 
-const Home: React.FC<any> = ({data, jumbotron, location}) => {
+const Home: React.FC<any> = ({
+  data,
+  jumbotron,
+  location,
+}: {
+  data: CuratedHomePageDataType
+  jumbotron: SanitySectionType
+  location: string
+}) => {
   const router = useRouter()
   const {data: completeCourseData} = trpc.progress.completedCourses.useQuery()
-  const completedCoursesIds =
-    !isEmpty(completeCourseData) &&
-    completeCourseData.map((course: any) => course.collection.id)
+  const completedCoursesIds = completeCourseData?.map(
+    (course): number => course.collection.id,
+  )
 
   React.useEffect(() => {
     const {query} = router
@@ -47,143 +46,11 @@ const Home: React.FC<any> = ({data, jumbotron, location}) => {
       </div>
       <div className="container">
         <main className="pt-8 sm:pt-16">
-          {data.sections
-            .filter((s: any) => s.slug !== 'jumbotron')
-            .map((section: any, i: number) => {
-              return section.slug === 'topics' ? (
-                <Topics data={section} key={i} />
-              ) : (
-                <section className="pb-16" key={section.slug}>
-                  {!section.image && !section.description ? (
-                    // simple section
-                    <div className="flex items-center justify-between w-full pb-6">
-                      <h2 className="text-lg font-semibold leading-tight lg:text-2xl sm:text-xl dark:text-white">
-                        {section.title}
-                      </h2>
-                    </div>
-                  ) : (
-                    // section with image and description
-                    <div className="flex flex-col items-center justify-center w-full pb-8 mb-5 md:flex-row md:items-start">
-                      {section.image && (
-                        <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
-                          <Image
-                            aria-hidden
-                            src={section.image}
-                            quality={100}
-                            width={320}
-                            height={320}
-                            alt=""
-                          />
-                        </div>
-                      )}
-                      <div>
-                        <h2 className="w-full pb-4 text-lg font-semibold leading-tight lg:text-2xl sm:text-xl dark:text-white">
-                          {section.title}
-                        </h2>
-                        {section.description && (
-                          <ReactMarkdown className="prose-sm prose text-gray-700 sm:prose dark:prose-dark dark:text-gray-300 dark:prose-a:text-blue-300 prose-a:text-blue-500">
-                            {section.description}
-                          </ReactMarkdown>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                  <Grid>
-                    {section.resources.map(
-                      (resource: CardResource, i: number) => {
-                        switch (section.resources.length) {
-                          case 3:
-                            return i === 0 ? (
-                              <HorizontalResourceCard
-                                className="col-span-2"
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            ) : (
-                              <VerticalResourceCard
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            )
-                          case 6:
-                            return i === 0 || i === 1 ? (
-                              <HorizontalResourceCard
-                                className="col-span-2"
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            ) : (
-                              <VerticalResourceCard
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            )
-                          case 7:
-                            return i === 0 ? (
-                              <HorizontalResourceCard
-                                className="col-span-2"
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            ) : (
-                              <VerticalResourceCard
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            )
-                          default:
-                            return (
-                              <VerticalResourceCard
-                                key={resource.id}
-                                resource={resource}
-                                location={location}
-                                completedCoursesIds={completedCoursesIds}
-                              />
-                            )
-                        }
-                      },
-                    )}
-                  </Grid>
-                  {section.path && (
-                    <div className="flex justify-end mt-3">
-                      <Link href={section.path} passHref>
-                        <a
-                          onClick={() => {
-                            analytics.events.activityInternalLinkClick(
-                              'curated topic page',
-                              'home page-curated section',
-                              section.title,
-                              section.path,
-                            )
-                          }}
-                          className="flex items-center px-4 py-3 text-sm transition-all duration-200 ease-in-out bg-transparent border-b-2 border-gray-200 dark:border-gray-800 border-opacity-70 dark:hover:bg-gray-800 dark:hover:bg-opacity-50 opacity-80 hover:opacity-100 group"
-                        >
-                          Browse all{' '}
-                          <span
-                            className="pl-1 transition-all duration-200 ease-in-out group-hover:translate-x-1"
-                            aria-hidden
-                          >
-                            →
-                          </span>
-                        </a>
-                      </Link>
-                    </div>
-                  )}
-                </section>
-              )
-            })}
+          <SanitySections
+            sections={data.sections}
+            location={location}
+            completedCoursesIds={completedCoursesIds}
+          />
           <Search />
         </main>
       </div>

--- a/src/components/pages/home/sanity-sections.tsx
+++ b/src/components/pages/home/sanity-sections.tsx
@@ -1,0 +1,188 @@
+import * as React from 'react'
+import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
+import {VerticalResourceCard} from 'components/card/new-vertical-resource-card'
+import Topics from 'components/pages/home/topics'
+import ReactMarkdown from 'react-markdown'
+import {CardResource} from 'types'
+import Grid from 'components/grid'
+import Image from 'next/image'
+import Link from 'next/link'
+import EggheadForTeamsCta from 'components/pages/home/egghead-for-teams-cta'
+import analytics from 'utils/analytics'
+import {SanitySectionType} from 'pages/learn'
+
+const DynamicGridComponent = ({
+  section,
+  location,
+  completedCoursesIds,
+}: {
+  section: SanitySectionType
+  location?: string
+  completedCoursesIds?: number[]
+}) => {
+  return (
+    <section className="pb-16" key={section.slug}>
+      {!section.image && !section.description ? (
+        // simple section
+        <div className="flex items-center justify-between w-full pb-6">
+          <h2 className="text-lg font-semibold leading-tight lg:text-2xl sm:text-xl dark:text-white">
+            {section.title}
+          </h2>
+        </div>
+      ) : (
+        // section with image and description
+        <div className="flex flex-col items-center justify-center w-full pb-8 mb-5 md:flex-row md:items-start">
+          {section.image && (
+            <div className="flex-shrink-0 md:max-w-none max-w-[200px]">
+              <Image
+                aria-hidden
+                src={section.image}
+                quality={100}
+                width={320}
+                height={320}
+                alt=""
+              />
+            </div>
+          )}
+          <div>
+            <h2 className="w-full pb-4 text-lg font-semibold leading-tight lg:text-2xl sm:text-xl dark:text-white">
+              {section.title}
+            </h2>
+            {section.description && (
+              <ReactMarkdown className="prose-sm prose text-gray-700 sm:prose dark:prose-dark dark:text-gray-300 dark:prose-a:text-blue-300 prose-a:text-blue-500">
+                {section.description}
+              </ReactMarkdown>
+            )}
+          </div>
+        </div>
+      )}
+      <Grid>
+        {section?.resources?.map((resource: CardResource, i: number) => {
+          switch (section?.resources?.length) {
+            case 3:
+              return i === 0 ? (
+                <HorizontalResourceCard
+                  className="col-span-2"
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              ) : (
+                <VerticalResourceCard
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              )
+            case 6:
+              return i === 0 || i === 1 ? (
+                <HorizontalResourceCard
+                  className="col-span-2"
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              ) : (
+                <VerticalResourceCard
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              )
+            case 7:
+              return i === 0 ? (
+                <HorizontalResourceCard
+                  className="col-span-2"
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              ) : (
+                <VerticalResourceCard
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              )
+            default:
+              return (
+                <VerticalResourceCard
+                  key={resource.id}
+                  resource={resource}
+                  location={location}
+                  completedCoursesIds={completedCoursesIds}
+                />
+              )
+          }
+        })}
+      </Grid>
+      {section.path && (
+        <div className="flex justify-end mt-3">
+          <Link href={section.path} passHref>
+            <a
+              onClick={() => {
+                analytics.events.activityInternalLinkClick(
+                  'curated topic page',
+                  'home page-curated section',
+                  section.title,
+                  section.path,
+                )
+              }}
+              className="flex items-center px-4 py-3 text-sm transition-all duration-200 ease-in-out bg-transparent border-b-2 border-gray-200 dark:border-gray-800 border-opacity-70 dark:hover:bg-gray-800 dark:hover:bg-opacity-50 opacity-80 hover:opacity-100 group"
+            >
+              Browse all{' '}
+              <span
+                className="pl-1 transition-all duration-200 ease-in-out group-hover:translate-x-1"
+                aria-hidden
+              >
+                →
+              </span>
+            </a>
+          </Link>
+        </div>
+      )}
+    </section>
+  )
+}
+
+const SanitySections = ({
+  sections,
+  location,
+  completedCoursesIds,
+}: {
+  sections: SanitySectionType[]
+  location?: string
+  completedCoursesIds?: number[]
+}) => {
+  return (
+    <>
+      {sections
+        .filter((s: any) => s.slug !== 'jumbotron')
+        .map((section: any, i: number) => {
+          switch (true) {
+            case section.slug === 'topics':
+              return <Topics data={section} key={i} />
+            case section.displayComponent === 'eggheadForTeamsCta':
+              return <EggheadForTeamsCta />
+          }
+
+          return (
+            <DynamicGridComponent
+              section={section}
+              key={i}
+              location={location}
+              completedCoursesIds={completedCoursesIds}
+            />
+          )
+        })}
+    </>
+  )
+}
+
+export default SanitySections

--- a/src/components/pages/home/sanity-sections.tsx
+++ b/src/components/pages/home/sanity-sections.tsx
@@ -157,7 +157,7 @@ const SanitySections = ({
   completedCoursesIds,
 }: {
   sections: SanitySectionType[]
-  location?: string
+  location: string
   completedCoursesIds?: number[]
 }) => {
   return (
@@ -169,7 +169,7 @@ const SanitySections = ({
             case section.slug === 'topics':
               return <Topics data={section} key={i} />
             case section.displayComponent === 'eggheadForTeamsCta':
-              return <EggheadForTeamsCta />
+              return <EggheadForTeamsCta location={location} />
           }
 
           return (

--- a/src/components/search/curated/[slug]/index.tsx
+++ b/src/components/search/curated/[slug]/index.tsx
@@ -26,7 +26,7 @@ const DynamicCardGrid = ({
   className,
 }: {
   section: any
-  completedCoursesIds: string[]
+  completedCoursesIds: number[]
   location: string
   className?: string
 }) => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,6 +45,7 @@ const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-hom
       title,
       'slug': slug.current,
       image,
+      displayComponent,
       path,
       description,
       'topics': resources[]{

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -88,11 +88,13 @@ const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-hom
 const Resource = z.object({
   id: z.string().optional(),
   externalId: z.number().optional(),
-  title: z.string(),
-  name: z.string(),
-  description: z.string(),
-  path: z.string(),
-  image: z.union([z.string(), z.object({src: z.string(), alt: z.string()})]),
+  title: z.string().optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  path: z.string().optional(),
+  image: z
+    .union([z.string(), z.object({src: z.string(), alt: z.string()})])
+    .optional(),
   images: z
     .object({
       label: z.string().optional(),
@@ -130,7 +132,7 @@ const SanitySection = z.object({
   path: z.string().optional(),
   description: z.string().optional(),
   topics: z.array(Topic).optional(),
-  resources: z.array(Resource).optional(),
+  resources: z.array(Resource).optional().nullish(),
 })
 export type SanitySectionType = z.infer<typeof SanitySection>
 
@@ -141,9 +143,10 @@ const CuratedHomePageData = z.object({
 export type CuratedHomePageDataType = z.infer<typeof CuratedHomePageData>
 
 export async function getStaticProps() {
-  const data = await sanityClient
-    .fetch(homepageQuery)
-    .then((result) => CuratedHomePageData.parse(result))
+  const data = await sanityClient.fetch(homepageQuery).then((result) => {
+    console.log({result})
+    return CuratedHomePageData.parse(result)
+  })
   const holidayCourses = saleOn ? await loadHolidayCourses() : {}
 
   return {

--- a/src/pages/learn/index.tsx
+++ b/src/pages/learn/index.tsx
@@ -68,6 +68,8 @@ const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-hom
         'name': type,
         'description': summary,
         path,
+        'slug': slug.current,
+        byline,
         image,
         images {
           label,
@@ -86,33 +88,27 @@ const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-hom
   }`
 
 const Resource = z.object({
-  id: z.string().optional(),
-  externalId: z.number().optional(),
-  title: z.string().optional(),
-  name: z.string().optional(),
-  description: z.string().optional(),
-  path: z.string().optional(),
-  image: z
-    .union([z.string(), z.object({src: z.string(), alt: z.string()})])
-    .optional(),
-  images: z
-    .object({
-      label: z.string().optional(),
-      url: z.string().optional(),
-    })
-    .optional(),
-  tag: z
-    .object({
-      name: z.string(),
-    })
-    .optional(),
-  ogImage: z.string().optional(),
-  instructor: z
-    .object({
-      name: z.string().optional(),
-      image: z.string().optional(),
-    })
-    .optional(),
+  id: z.string(),
+  externalId: z.number(),
+  title: z.string(),
+  name: z.string(),
+  description: z.string(),
+  path: z.string(),
+  slug: z.string(),
+  byline: z.string(),
+  image: z.union([z.string(), z.object({src: z.string(), alt: z.string()})]),
+  images: z.object({
+    label: z.string(),
+    url: z.string(),
+  }),
+  tag: z.object({
+    name: z.string(),
+  }),
+  ogImage: z.string(),
+  instructor: z.object({
+    name: z.string(),
+    image: z.string(),
+  }),
 })
 export type SanityResourceType = z.infer<typeof Resource>
 
@@ -132,7 +128,7 @@ const SanitySection = z.object({
   path: z.string().optional(),
   description: z.string().optional(),
   topics: z.array(Topic).optional(),
-  resources: z.array(Resource).optional().nullish(),
+  resources: z.array(Resource).nullish(),
 })
 export type SanitySectionType = z.infer<typeof SanitySection>
 
@@ -143,10 +139,7 @@ const CuratedHomePageData = z.object({
 export type CuratedHomePageDataType = z.infer<typeof CuratedHomePageData>
 
 export async function getStaticProps() {
-  const data = await sanityClient.fetch(homepageQuery).then((result) => {
-    console.log({result})
-    return CuratedHomePageData.parse(result)
-  })
+  const data = await sanityClient.fetch(homepageQuery)
   const holidayCourses = saleOn ? await loadHolidayCourses() : {}
 
   return {

--- a/src/trpc/routers/progress.ts
+++ b/src/trpc/routers/progress.ts
@@ -5,30 +5,13 @@ import {loadLessonProgress, loadPlaylistProgress} from '../../lib/progress'
 import {loadUserCompletedCourses} from 'lib/users'
 
 export const progressRouter = router({
-  completedCourses: baseProcedure
-    .output(
-      z.array(
-        z.object({
-          completed_at: z.string(),
-          lesson_count: z.number(),
-          is_complete: z.boolean(),
-          collection: z.object({
-            slug: z.string(),
-            title: z.string(),
-            image: z.string(),
-            path: z.string(),
-            id: z.number(),
-          }),
-        }),
-      ),
-    )
-    .query(async ({ctx}) => {
-      const token = ctx.req?.cookies[ACCESS_TOKEN_KEY]
-      if (!token) return []
+  completedCourses: baseProcedure.query(async ({ctx}) => {
+    const token = ctx.req?.cookies[ACCESS_TOKEN_KEY]
+    if (!token) return []
 
-      const {completeCourses} = await loadUserCompletedCourses(token)
-      return completeCourses
-    }),
+    const {completeCourses} = await loadUserCompletedCourses(token)
+    return completeCourses
+  }),
   forPlaylist: baseProcedure
     .input(
       z.object({

--- a/src/trpc/routers/progress.ts
+++ b/src/trpc/routers/progress.ts
@@ -5,13 +5,30 @@ import {loadLessonProgress, loadPlaylistProgress} from '../../lib/progress'
 import {loadUserCompletedCourses} from 'lib/users'
 
 export const progressRouter = router({
-  completedCourses: baseProcedure.query(async ({ctx}) => {
-    const token = ctx.req?.cookies[ACCESS_TOKEN_KEY]
-    if (!token) return []
+  completedCourses: baseProcedure
+    .output(
+      z.array(
+        z.object({
+          completed_at: z.string(),
+          lesson_count: z.number(),
+          is_complete: z.boolean(),
+          collection: z.object({
+            slug: z.string(),
+            title: z.string(),
+            image: z.string(),
+            path: z.string(),
+            id: z.number(),
+          }),
+        }),
+      ),
+    )
+    .query(async ({ctx}) => {
+      const token = ctx.req?.cookies[ACCESS_TOKEN_KEY]
+      if (!token) return []
 
-    const {completeCourses} = await loadUserCompletedCourses(token)
-    return completeCourses
-  }),
+      const {completeCourses} = await loadUserCompletedCourses(token)
+      return completeCourses
+    }),
   forPlaylist: baseProcedure
     .input(
       z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,21 +1,21 @@
 export type Resource = {
-  title?: string
-  slug?: string
-  description?: string
+  title: string
+  slug: string
+  description: string
   icon_url?: string
   completed?: boolean
-  path?: string
+  path: string
   type?: string
 }
 
 export type CardResource = Resource & {
   id?: string
   externalId?: number
-  image?: string | {src: string; alt: string}
-  name?: string
+  image: string | {src: string; alt: string}
+  name: string
   tag?: any
   subTitle?: string
-  byline?: string
+  byline: string
   resources?: CardResource[]
   related?: CardResource[]
   instructor?: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type Resource = {
   title: string
-  slug: string
+  slug?: string
   description: string
   icon_url?: string
   completed?: boolean
@@ -10,12 +10,12 @@ export type Resource = {
 
 export type CardResource = Resource & {
   id?: string
-  externalId?: string
+  externalId?: number
   image: string | {src: string; alt: string}
   name: string
   tag?: any
   subTitle?: string
-  byline: string
+  byline?: string
   resources?: CardResource[]
   related?: CardResource[]
   instructor?: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,18 @@
 export type Resource = {
-  title: string
+  title?: string
   slug?: string
-  description: string
+  description?: string
   icon_url?: string
   completed?: boolean
-  path: string
+  path?: string
   type?: string
 }
 
 export type CardResource = Resource & {
   id?: string
   externalId?: number
-  image: string | {src: string; alt: string}
-  name: string
+  image?: string | {src: string; alt: string}
+  name?: string
   tag?: any
   subTitle?: string
   byline?: string

--- a/src/utils/analytics/events.ts
+++ b/src/utils/analytics/events.ts
@@ -139,7 +139,7 @@ export const activityInternalLinkClick = (
   resourceType: string,
   currentLocation: string,
   topic: string,
-  redirectTo: string,
+  redirectTo?: string,
   instructor?: string,
 ) =>
   track('clicked internal link', {

--- a/src/utils/analytics/events.ts
+++ b/src/utils/analytics/events.ts
@@ -174,9 +174,9 @@ export const activityExternalLinkClick = (
 export const activityCtaClick = (
   resourceType: string,
   currentLocation: string,
+  redirectTo?: string,
   instructor?: string,
   topic?: string,
-  redirectTo?: string,
 ) =>
   track('clicked CTA', {
     eventGroup: 'activity',

--- a/studio/schemas/documents/resource.js
+++ b/studio/schemas/documents/resource.js
@@ -126,6 +126,27 @@ export default {
       },
     },
     {
+      name: 'displayComponent',
+      type: 'string',
+      title: 'Display Component',
+      description:
+        'What component should be used in egghead-next to display this feature?',
+      // hidden: ({document}) => document.type !== 'feature',
+      options: {
+        list: [
+          {
+            title: 'Dynamic Grid',
+            value: 'DynamicGrid',
+            default: true,
+          },
+          {
+            title: 'egghead For Teams CTA',
+            value: 'eggheadForTeamsCta',
+          },
+        ],
+      },
+    },
+    {
       name: 'productionProcessState',
       title: 'Production Process State',
       type: 'productionProcessState',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,6 +124,43 @@ module.exports = {
       lineHeight: {
         tighter: 1.1,
       },
+      animation: {
+        'gradient-x': 'gradient-x 10s ease infinite',
+        'gradient-y': 'gradient-y 10s ease infinite',
+        'gradient-xy': 'gradient-xy 10s ease infinite',
+      },
+      keyframes: {
+        'gradient-y': {
+          '0%, 100%': {
+            'background-size': '400% 400%',
+            'background-position': 'center top',
+          },
+          '50%': {
+            'background-size': '200% 200%',
+            'background-position': 'center center',
+          },
+        },
+        'gradient-x': {
+          '0%, 100%': {
+            'background-size': '200% 200%',
+            'background-position': 'left center',
+          },
+          '50%': {
+            'background-size': '200% 200%',
+            'background-position': 'right center',
+          },
+        },
+        'gradient-xy': {
+          '0%, 100%': {
+            'background-size': '400% 400%',
+            'background-position': 'left center',
+          },
+          '50%': {
+            'background-size': '200% 200%',
+            'background-position': 'right center',
+          },
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
The homepage is a dynamically rendered list of sections based on what the page receives from Sanity. Up to this point we only displayed one type of component, a section that displayed a header, some text and a dynamic grid of resource cards. 

This PR updates the home page behavior to allow for us to control what component is used for a section on the page. 

We want to show an "egghead for teams CTA" so this PR adds the first custom display component `EggheadForTeamsCTA`. The default will be the existing section behavior that we already see on the home page.

## DynamicGrid Component:
![Dynamic grid component](https://user-images.githubusercontent.com/6188161/236550810-f73d6e7d-82a2-42ff-9746-d5a15ca7b2b2.png)

## EggheadForTeamsCTA

![EggheadForTeamsCTA dark desktop](https://user-images.githubusercontent.com/6188161/236550903-087329ea-dd44-4e16-9c7a-5134b92d31a8.png)
![EggheadForTeamsCTA light desktop](https://user-images.githubusercontent.com/6188161/236550993-9869451d-4269-4b3c-8844-81e99268e619.png)
![EggheadForTeamsCTA dark mobile](https://user-images.githubusercontent.com/6188161/236550919-b4a7579d-8a41-4b70-91af-53f0a8be3661.png)
![EggheadForTeamsCTA light mobile](https://user-images.githubusercontent.com/6188161/236551003-fe6a0c0e-8804-4774-9713-e9c703f1aa59.png)
