### PR TITLE
fix: make button text visible for light mode

### DIFF
--- a/src/components/pages/user/tabs-content/profile-tab-content.tsx
+++ b/src/components/pages/user/tabs-content/profile-tab-content.tsx
@@ -60,7 +60,7 @@ const GithubDisConnectButton: React.FunctionComponent<{
   return (
     <button
       onClick={handleClick}
-      className="inline-block px-4 py-3 text-white border-blue-600 border rounded focus:outline-none hover:bg-blue-700"
+      className="inline-block px-4 py-3 text-gray-900 hover:text-white dark:text-white border-blue-600 border rounded focus:outline-none hover:bg-blue-700"
     >
       Disconnect Your GitHub Account
     </button>
@@ -73,7 +73,7 @@ const GithubConnectButton: React.FunctionComponent<{
   return (
     <a
       href={`${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/users/github_passthrough?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}&auth_token=${authToken}`}
-      className="inline-block px-4 py-3 text-white bg-blue-600 border-0 rounded focus:outline-none hover:bg-blue-700"
+      className="inline-block px-4 py-3 text-gray-900 hover:text-white dark:text-white border-blue-600 border rounded focus:outline-none hover:bg-blue-700"
     >
       Connect Your GitHub Account
     </a>


### PR DESCRIPTION
I noticed this button text was rendering as white on white in light mode, so put in a quick fix so that it looks good in both light and dark mode.

### Before

![CleanShot 2023-05-08 at 10 34 45](https://user-images.githubusercontent.com/694063/236869800-3f789caa-fd8f-41df-bf5e-f0729097b909.gif)

### After

![CleanShot 2023-05-08 at 10 42 43](https://user-images.githubusercontent.com/694063/236869823-6398eb21-e5d0-4a5f-956d-8ba278369ae8.gif)

![light](https://media3.giphy.com/media/xTk9ZZRGWEelhRiEak/giphy.gif?cid=d1fd59abkdkzrq4dqvctyf74skn1f0f50g6h0wlyg56tc7f3&ep=v1_gifs_search&rid=giphy.gif&ct=g)