### PR TITLE
fix: load tags from cloudinary

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -885,6 +885,9 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
               <div>
                 <ul>
                   {lessons.map((lesson: LessonResource, index: number) => {
+                    const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/v1683914713/tags/${lesson?.primary_tag?.name}.png`
+                    const optimizedImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/fetch/w_72,h_72/${tagImageUrl}`
+
                     const isComplete = completedLessonSlugs?.includes(
                       lesson.slug,
                     )
@@ -905,10 +908,10 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                                 index + 1
                               )}
                             </div>
-                            {lesson.icon_url && (
+                            {lesson.primary_tag && (
                               <div className="flex items-center flex-shrink-0 w-8">
                                 <Image
-                                  src={lesson.icon_url}
+                                  src={optimizedImageUrl}
                                   width={24}
                                   height={24}
                                 />

--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -885,8 +885,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
               <div>
                 <ul>
                   {lessons.map((lesson: LessonResource, index: number) => {
-                    const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/v1683914713/tags/${lesson?.primary_tag?.name}.png`
-                    const optimizedImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/fetch/w_72,h_72/${tagImageUrl}`
+                    const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/w_72,h_72/v1683914713/tags/${lesson?.primary_tag?.name}.png`
 
                     const isComplete = completedLessonSlugs?.includes(
                       lesson.slug,
@@ -911,7 +910,7 @@ const CollectionPageLayout: React.FunctionComponent<CoursePageLayoutProps> = ({
                             {lesson.primary_tag && (
                               <div className="flex items-center flex-shrink-0 w-8">
                                 <Image
-                                  src={optimizedImageUrl}
+                                  src={tagImageUrl}
                                   width={24}
                                   height={24}
                                 />

--- a/src/components/pages/lessons/tags.tsx
+++ b/src/components/pages/lessons/tags.tsx
@@ -44,8 +44,7 @@ const Tags: React.FC<{
           {/* <div className="font-medium">Tech used:</div> */}
           <ul className="grid items-center grid-flow-col-dense gap-5 text-sm">
             {collectionTags.map((tag: TagWithVersion, index: number) => {
-              const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/v1683914713/tags/${tag.name}.png`
-              const optimizedImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/fetch/w_72,h_72/${tagImageUrl}`
+              const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/w_72,h_72/v1683914713/tags/${tag.name}.png`
 
               return (
                 <li key={index} className="inline-flex items-center">
@@ -60,7 +59,7 @@ const Tags: React.FC<{
                       className="inline-flex items-center hover:underline"
                     >
                       <Image
-                        src={optimizedImageUrl}
+                        src={tagImageUrl}
                         alt={tag.name}
                         width={20}
                         height={20}

--- a/src/components/pages/lessons/tags.tsx
+++ b/src/components/pages/lessons/tags.tsx
@@ -43,35 +43,40 @@ const Tags: React.FC<{
         <div className="flex items-center space-x-4">
           {/* <div className="font-medium">Tech used:</div> */}
           <ul className="grid items-center grid-flow-col-dense gap-5 text-sm">
-            {collectionTags.map((tag: TagWithVersion, index: number) => (
-              <li key={index} className="inline-flex items-center">
-                <Link href={`/q/${tag.name}`}>
-                  <a
-                    onClick={() => {
-                      track(`clicked view topic`, {
-                        lesson: lessonSlug,
-                        topic: tag.name,
-                      })
-                    }}
-                    className="inline-flex items-center hover:underline"
-                  >
-                    <Image
-                      src={tag.image_url}
-                      alt={tag.name}
-                      width={20}
-                      height={20}
-                      className="flex-shrink-0"
-                    />
-                    <span className="ml-1">{tag.label}</span>
-                    {tag.version && (
-                      <span className="ml-2">
-                        <code>{tag.version}</code>
-                      </span>
-                    )}
-                  </a>
-                </Link>
-              </li>
-            ))}
+            {collectionTags.map((tag: TagWithVersion, index: number) => {
+              const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/v1683914713/tags/${tag.name}.png`
+              const optimizedImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/fetch/w_72,h_72/${tagImageUrl}`
+
+              return (
+                <li key={index} className="inline-flex items-center">
+                  <Link href={`/q/${tag.name}`}>
+                    <a
+                      onClick={() => {
+                        track(`clicked view topic`, {
+                          lesson: lessonSlug,
+                          topic: tag.name,
+                        })
+                      }}
+                      className="inline-flex items-center hover:underline"
+                    >
+                      <Image
+                        src={optimizedImageUrl}
+                        alt={tag.name}
+                        width={20}
+                        height={20}
+                        className="flex-shrink-0"
+                      />
+                      <span className="ml-1">{tag.label}</span>
+                      {tag.version && (
+                        <span className="ml-2">
+                          <code>{tag.version}</code>
+                        </span>
+                      )}
+                    </a>
+                  </Link>
+                </li>
+              )
+            })}
           </ul>
         </div>
       )}

--- a/src/lib/playlists.ts
+++ b/src/lib/playlists.ts
@@ -223,6 +223,9 @@ export async function loadPlaylist(slug: string, token?: string) {
             created_at
             updated_at
             published_at
+            primary_tag {
+              name
+            }
           }
           ... on File {
             slug

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type LessonResource = Resource & {
   id: string | number
   tags: any[]
   lessons: any[]
+  primary_tag: any
   completed: boolean
   duration: number
   instructor: any


### PR DESCRIPTION
This doesn't fix the underlying issue of tag images being broken coming from rails (we should probably migrate lessons to sanity but this is a big task) but this fixes images by loading tag images from cloudinary based on tag name that is present.

![tag](https://media.giphy.com/media/xUA7bcdpjjKrnbh37W/giphy.gif)