### PR TITLE
fix: pull default course image from cloudinary

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -6,6 +6,7 @@ const courseQuery = groq`
 *[_type == 'resource' && externalId == $courseId][0]{
   title,
   challengeRating,
+  "square_cover_480_url": image,
   description,
   summary,
   essentialQuestions[]->{
@@ -80,8 +81,11 @@ export async function loadCourseMetadata(id: number) {
 
   const course = await sanityClient.fetch(courseQuery, params)
 
-  if (course?.illustration?.url) {
-    course['square_cover_480_url'] = course.illustration.url
+  if (!course?.square_cover_480_url) {
+    const imageUrl = course?.dependencies
+      ? `https://res.cloudinary.com/dg3gyk0gu/image/upload/v1683914713/tags/${course?.dependencies[0]?.name}.png`
+      : 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1569292667/eggo/eggo_flair.png'
+    course['square_cover_480_url'] = imageUrl
   }
 
   return course


### PR DESCRIPTION
Realized that the course artwork pulls in the primary tag image as well when there is no custom artwork supplied. This patches that to return the first tag set in sanity as the default course image


## broken prod
![broken](https://github.com/skillrecordings/egghead-next/assets/6188161/46d1c7d6-0c5b-43b0-bc1a-1683b2a4f579)

## fixed local
![fixed](https://github.com/skillrecordings/egghead-next/assets/6188161/56f8c6c5-4c88-4b62-b1a3-5bc6c962495e)


![again](https://media.giphy.com/media/ryQDjtPSPfgeA/giphy.gif)