### PR TITLE
CSS Guide Page

### DIFF
--- a/src/pages/guides/just-enough-css-for-modern-app-development.tsx
+++ b/src/pages/guides/just-enough-css-for-modern-app-development.tsx
@@ -3,16 +3,16 @@ import {NextSeo} from 'next-seo'
 import Image from 'next/image'
 import {useRouter} from 'next/router'
 import {sanityClient} from 'utils/sanity-client'
+import removeMarkdown from 'remove-markdown'
 import {
   ArrowDownIcon,
   SparklesIcon,
   LightningBoltIcon,
 } from '@heroicons/react/solid'
-import {Textfit} from 'react-textfit'
-import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import Link from 'next/link'
 import {twMerge} from 'tailwind-merge'
 import React from 'react'
+import {truncate} from 'lodash'
 
 const HorizontalCourseCard: React.FC<{
   course: any
@@ -171,7 +171,8 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
 }) => {
   const scrollRef = React.useRef<null | HTMLHeadingElement>(null)
 
-  const {sections} = cssGuide
+  const {sections, ogImage} = cssGuide
+
   const [fundamentalSection, layoutSection, modernSection] = sections
 
   const router = useRouter()
@@ -180,16 +181,21 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
   return (
     <>
       <NextSeo
-        title={cssGuide.title}
-        description={cssGuide.description}
+        title={truncate(cssGuide.title, {length: 65})}
+        description={truncate(removeMarkdown(cssGuide.description), {
+          length: 155,
+        })}
         openGraph={{
-          title: cssGuide.title,
-          description: cssGuide.description,
+          title: truncate(cssGuide.title, {length: 65}),
+          description: truncate(removeMarkdown(cssGuide.description), {
+            length: 155,
+          }),
           url,
+          site_name: 'egghead',
           images: [
             {
-              url: cssGuide.ogImage,
-              alt: cssGuide.title,
+              url: ogImage,
+              alt: truncate(cssGuide.title, {length: 65}),
             },
           ],
         }}
@@ -351,6 +357,7 @@ const query = groq`*[_type == 'resource' && type == 'landing-page' && slug.curre
   'featureImage': images[label == 'feature-image'][0].url,
   'backgroundGrid': images[label == 'background-grid'][0].url,
   'weekGrid': images[label == 'week-grid'][0].url,
+  'ogImage': images[label == 'og-image'][0].url,
   description,
   'sections': resources[] {
     title,

--- a/src/pages/guides/just-enough-css-for-modern-app-development.tsx
+++ b/src/pages/guides/just-enough-css-for-modern-app-development.tsx
@@ -21,11 +21,11 @@ const HorizontalCourseCard: React.FC<{
     <Link href={course.path}>
       <div
         className={twMerge(
-          'flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center px-5 py-8 group dark:bg-gray-800 bg-gray-50 dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 rounded sm:h-64 sm:w-[500px] cursor-pointer',
+          'flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center px-5 py-8 group dark:bg-gray-800 bg-gray-100 dark:bg-opacity-60 hover:shadow-none transition-all shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 rounded sm:h-64 sm:w-[500px] cursor-pointer',
           className,
         )}
       >
-        <div className="w-fit shrink-0">
+        <div className="w-fit shrink-0 hover:scale-105 transition-all">
           <Image
             src={course.image}
             height={150}
@@ -48,25 +48,55 @@ const HorizontalCourseCard: React.FC<{
   )
 }
 
-const CssChallengeCard = () => {
+const CssChallengeCard = ({challenge}: {challenge: any}) => {
+  const isExternal = !!challenge?.externalPath
+
+  if (isExternal) {
+    return (
+      <a
+        href={challenge.externalPath}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <div className="flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center p-8 group bg-blue-500 hover:shadow-none transition-all shadow-smooth hover:bg-blue-600 w-fit rounded h-fit mb-4 cursor-pointer">
+          <div className="text-center sm:text-left">
+            <div className="flex gap-2">
+              <SparklesIcon className="h-10 w-10 text-amber-300" />
+              <h3 className="text-xl font-semibold leading-tight self-center text-white">
+                {challenge.title}
+              </h3>
+            </div>
+
+            <p className="w-[35ch] leading-relaxed mt-4  text-white">
+              {challenge.description}
+            </p>
+
+            <button className="bg-white p-4 rounded text-blue-500 font-medium mt-14 transition-all hover:scale-105">
+              {challenge.ctaText}
+            </button>
+          </div>
+        </div>
+      </a>
+    )
+  }
+
   return (
-    <Link href="/projects/build-modern-layouts-with-css-grid">
-      <div className="flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center p-8 group bg-blue-500 shadow-smooth dark:hover:bg-blue-600 w-fit rounded h-fit mb-4 cursor-pointer">
+    <Link href={challenge.eggheadPath}>
+      <div className="flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center p-8 group bg-blue-500 hover:shadow-none transition-all shadow-smooth hover:bg-blue-600 w-fit rounded h-fit mb-4 cursor-pointer">
         <div className="text-center sm:text-left">
           <div className="flex gap-2">
             <SparklesIcon className="h-10 w-10 text-amber-300" />
-            <h3 className="text-xl font-semibold leading-tight self-center">
-              Ready for a CSS Layout Challenge?
+            <h3 className="text-xl font-semibold leading-tight self-center text-white">
+              {challenge.title}
             </h3>
           </div>
 
-          <p className="w-[35ch] leading-relaxed mt-4">
-            Apply what you know to this Portfolio Challenge that will test your
-            ability to create a responsive design with two different layouts.
+          <p className="w-[35ch] leading-relaxed mt-4  text-white">
+            {challenge.description}
           </p>
 
-          <button className="bg-white p-4 rounded text-blue-500 font-medium mt-14">
-            Take this CSS Challenge
+          <button className="bg-white p-4 rounded text-blue-500 font-medium mt-14 transition-all hover:scale-105">
+            {challenge.ctaText}
           </button>
         </div>
       </div>
@@ -74,31 +104,64 @@ const CssChallengeCard = () => {
   )
 }
 
-const CssChallengeCardFull = () => {
-  return (
-    <div className="flex flex-col sm:flex-row flex-wrap justify-center gap-4 mt-4">
-      <div className="px-5 py-8 group bg-blue-500 shadow-smooth dark:hover:bg-blue-600 w-full rounded h-fit mb-4">
-        <div className="flex flex-row justify-center sm:justify-between text-center flex-wrap sm:text-left lg:mx-20 gap-4">
-          <div className="flex flex-wrap justify-center gap-4">
-            <LightningBoltIcon className="h-10 w-10 text-amber-300" />
-            <div className="flex flex-col gap-2">
-              <h3 className="text-xl font-semibold leading-tight self-center">
-                Ready for a TailwindCSS Challenge?
-              </h3>
-              <p className="w-[35ch] leading-relaxed self-center sm:self-auto ">
-                Apply what you know to this Portfolio Challenge that will test
-                your ability to create a responsive design with two different
-                layouts.
-              </p>
+const CssChallengeCardFull = ({challenge}: {challenge: any}) => {
+  const isExternal = !!challenge?.externalPath
+
+  if (isExternal) {
+    return (
+      <a
+        href={challenge.externalPath}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <div className="flex flex-col sm:flex-row flex-wrap justify-center gap-4 mt-4">
+          <div className="px-5 py-8 group bg-blue-500 shadow-smooth dark:hover:bg-blue-600 w-full rounded h-fit mb-4 hover:bg-blue-600 hover:shadow-none transition-all">
+            <div className="flex flex-row justify-center sm:justify-between text-center flex-wrap sm:text-left lg:mx-20 gap-4">
+              <div className="flex flex-wrap justify-center gap-4">
+                <LightningBoltIcon className="h-10 w-10 text-amber-300" />
+                <div className="flex flex-col gap-2">
+                  <h3 className="text-xl font-semibold leading-tight self-center  text-white">
+                    {challenge.title}
+                  </h3>
+                  <p className="w-[35ch] leading-relaxed self-center sm:self-auto  text-white">
+                    {challenge.description}
+                  </p>
+                </div>
+              </div>
+
+              <button className="bg-white p-4 rounded text-blue-500 font-medium self-center hover:scale-105 transition-all">
+                {challenge.ctaText}
+              </button>
             </div>
           </div>
+        </div>
+      </a>
+    )
+  }
 
-          <button className="bg-white p-4 rounded text-blue-500 font-medium self-center">
-            Take this CSS Challenge
-          </button>
+  return (
+    <Link href={challenge.eggheadPath}>
+      <div className="flex flex-col sm:flex-row flex-wrap justify-center gap-4 mt-4">
+        <div className="px-5 py-8 group bg-blue-500 shadow-smooth dark:hover:bg-blue-600 w-full rounded h-fit mb-4 hover:bg-blue-600 hover:shadow-none transition-all">
+          <div className="flex flex-row justify-center sm:justify-between text-center flex-wrap sm:text-left lg:mx-20 gap-4">
+            <div className="flex flex-wrap justify-center gap-4">
+              <LightningBoltIcon className="h-10 w-10 text-amber-300" />
+              <div className="flex flex-col gap-2">
+                <h3 className="text-xl font-semibold leading-tight self-center  text-white">
+                  {challenge.title}
+                </h3>
+                <p className="w-[35ch] leading-relaxed self-center sm:self-auto  text-white">
+                  {challenge.description}
+                </p>
+              </div>
+            </div>
+            <button className="bg-white p-4 rounded text-blue-500 font-medium self-center hover:scale-105 transition-all">
+              {challenge.ctaText}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }
 
@@ -153,12 +216,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
             </div>
             <div>
               <h1 className="self-center mb-2 text-xl font-medium sm:text-2xl h-fit w-96">
-                <Textfit>
-                  Just enough <strong>CSS</strong> to build{' '}
-                  <span className="border-b-4 border-b-[#2eb9e3] ">
-                    Modern UI
-                  </span>
-                </Textfit>
+                Just enough <strong>CSS</strong> to build Modern UI
               </h1>
               <p className="whitespace-pre-wrap w-[40ch] mt-4">
                 {cssGuide.description}
@@ -197,7 +255,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
           </div>
         </section>
 
-        <section className="w-full dark:bg-gray-800 pb-20">
+        <section className="w-full dark:bg-gray-800 bg-gray-50 pb-20">
           <div className="max-w-screen-lg mx-auto">
             <div className="flex flex-col-reverse lg:flex-row lg:justify-between mt-20 mb-8 relative">
               <h2 className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left">
@@ -219,7 +277,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
               <p className="w-[40ch] mb-8 whitespace-pre-wrap mx-auto sm:mx-0">
                 {layoutSection.description}
               </p>
-              <CssChallengeCard />
+              <CssChallengeCard challenge={layoutSection.challenge} />
             </div>
             <div className="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
               <HorizontalCourseCard
@@ -265,7 +323,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
                 className=" col-span-4"
               />
             </div>
-            <CssChallengeCardFull />
+            <CssChallengeCardFull challenge={modernSection.challenge} />
           </div>
         </section>
       </div>
@@ -284,6 +342,13 @@ const query = groq`*[_type == 'resource' && type == 'landing-page' && slug.curre
   'sections': resources[] {
     title,
     description,
+    'challenge': resources[type == 'project'][0] {
+      title,
+      description,
+      'eggheadPath': path,
+      'externalPath': url,
+      'ctaText': content[label == "CTA"][0].text,
+     },
     'courses': resources[]->{
       title,
       'description': summary,

--- a/src/pages/guides/just-enough-css-for-modern-app-development.tsx
+++ b/src/pages/guides/just-enough-css-for-modern-app-development.tsx
@@ -1,0 +1,308 @@
+import groq from 'groq'
+import {NextSeo} from 'next-seo'
+import Image from 'next/image'
+import {useRouter} from 'next/router'
+import {sanityClient} from 'utils/sanity-client'
+import {
+  ArrowDownIcon,
+  SparklesIcon,
+  LightningBoltIcon,
+} from '@heroicons/react/solid'
+import {Textfit} from 'react-textfit'
+import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
+import Link from 'next/link'
+import {twMerge} from 'tailwind-merge'
+
+const HorizontalCourseCard: React.FC<{
+  course: any
+  className?: string
+}> = ({course, className = ''}) => {
+  return (
+    <Link href={course.path}>
+      <div
+        className={twMerge(
+          'flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center px-5 py-8 group dark:bg-gray-800 bg-gray-50 dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 rounded sm:h-64 sm:w-[500px] cursor-pointer',
+          className,
+        )}
+      >
+        <div className="w-fit shrink-0">
+          <Image
+            src={course.image}
+            height={150}
+            width={150}
+            alt={course.title}
+          />
+        </div>
+        <div className="space-y-2 text-center sm:text-left">
+          <h3 className="text-xl font-semibold leading-tight max-w-[20ch]">
+            {course.title}
+          </h3>
+
+          <p className="mt-1 uppercase font-medium sm:text-[0.65rem] text-[0.55rem] text-gray-700 dark:text-indigo-100 opacity-60">
+            {course.byline}
+          </p>
+          <p className="w-[35ch] text-sm">{course.description}</p>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+const CssChallengeCard = () => {
+  return (
+    <Link href="/projects/build-modern-layouts-with-css-grid">
+      <div className="flex justify-center flex-wrap sm:flex-nowrap  sm:flex-row gap-5 items-center p-8 group bg-blue-500 shadow-smooth dark:hover:bg-blue-600 w-fit rounded h-fit mb-4 cursor-pointer">
+        <div className="text-center sm:text-left">
+          <div className="flex gap-2">
+            <SparklesIcon className="h-10 w-10 text-amber-300" />
+            <h3 className="text-xl font-semibold leading-tight self-center">
+              Ready for a CSS Layout Challenge?
+            </h3>
+          </div>
+
+          <p className="w-[35ch] leading-relaxed mt-4">
+            Apply what you know to this Portfolio Challenge that will test your
+            ability to create a responsive design with two different layouts.
+          </p>
+
+          <button className="bg-white p-4 rounded text-blue-500 font-medium mt-14">
+            Take this CSS Challenge
+          </button>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+const CssChallengeCardFull = () => {
+  return (
+    <div className="flex flex-col sm:flex-row flex-wrap justify-center gap-4 mt-4">
+      <div className="px-5 py-8 group bg-blue-500 shadow-smooth dark:hover:bg-blue-600 w-full rounded h-fit mb-4">
+        <div className="flex flex-row justify-center sm:justify-between text-center flex-wrap sm:text-left lg:mx-20 gap-4">
+          <div className="flex flex-wrap justify-center gap-4">
+            <LightningBoltIcon className="h-10 w-10 text-amber-300" />
+            <div className="flex flex-col gap-2">
+              <h3 className="text-xl font-semibold leading-tight self-center">
+                Ready for a TailwindCSS Challenge?
+              </h3>
+              <p className="w-[35ch] leading-relaxed self-center sm:self-auto ">
+                Apply what you know to this Portfolio Challenge that will test
+                your ability to create a responsive design with two different
+                layouts.
+              </p>
+            </div>
+          </div>
+
+          <button className="bg-white p-4 rounded text-blue-500 font-medium self-center">
+            Take this CSS Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
+  cssGuide,
+}) => {
+  const {sections} = cssGuide
+  const [fundamentalSection, layoutSection, modernSection] = sections
+
+  const router = useRouter()
+
+  const url = process.env.NEXT_PUBLIC_DEPLOYMENT_URL + router.asPath
+  return (
+    <>
+      <NextSeo
+        title={cssGuide.title}
+        description={cssGuide.description}
+        openGraph={{
+          title: cssGuide.title,
+          description: cssGuide.description,
+          url,
+          images: [
+            {
+              url: cssGuide.ogImage,
+              alt: cssGuide.title,
+            },
+          ],
+        }}
+        twitter={{
+          cardType: 'summary_large_image',
+          site: 'eggheadio',
+        }}
+        canonical={url}
+      />
+      <div className="w-full mt-8 md:mt-14 lg:mt-32 mb-20">
+        <header className="relative w-full mx-auto">
+          <img
+            className="absolute -top-[100px] object-fill overflow-visible bg-no-repeat left-[10px]"
+            src={cssGuide.backgroundGrid}
+          />
+          <div className="relative z-10 flex flex-wrap w-full justify-center sm:justify-evenly gap-4 mx-auto">
+            <div>
+              <Image
+                src={cssGuide.featureImage}
+                alt={cssGuide.title}
+                objectFit="cover"
+                width={325}
+                height={325}
+                objectPosition="center"
+                className="shrink-0"
+              />
+            </div>
+            <div>
+              <h1 className="self-center mb-2 text-xl font-medium sm:text-2xl h-fit w-96">
+                <Textfit>
+                  Just enough <strong>CSS</strong> to build{' '}
+                  <span className="border-b-4 border-b-[#2eb9e3] ">
+                    Modern UI
+                  </span>
+                </Textfit>
+              </h1>
+              <p className="whitespace-pre-wrap w-[40ch] mt-4">
+                {cssGuide.description}
+              </p>
+            </div>
+          </div>
+          <div className="p-2 mx-auto mt-20 sm:mt-32 rounded-full  w-fit bg-gray-50 dark:bg-opacity-20 dark:text-gray-200 relative z-10">
+            <ArrowDownIcon className="w-5 h-5 text-gray-900 dark:text-white" />
+          </div>
+        </header>
+        <section className="w-full pb-20">
+          <div className="max-w-screen-lg mx-auto">
+            <div className="flex flex-col-reverse lg:flex-row lg:justify-between mt-20 mb-8 relative">
+              <h2 className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left">
+                {fundamentalSection.title}
+              </h2>
+              <div
+                aria-hidden
+                className="flex flex-col lg:mt-20 mb-8 font-mono text-2xl font-bold leading-[0.9] text-gray-400 dark:text-gray-700 self-center relative z-10 text-right"
+              >
+                <span className="text-xl">Week </span>
+                01
+              </div>
+              <img
+                className="absolute object-fill overflow-visible bg-no-repeat -top-20 right-[20%] sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
+                src={cssGuide.backgroundGrid}
+              />
+            </div>
+            <div className="flex flex-wrap justify-center lg:justify-between lg:flex-nowrap gap-4">
+              <div className="w-[40ch] mb-8 whitespace-pre-wrap mx-auto sm:mx-0 self-center">
+                {fundamentalSection.description}
+              </div>
+
+              <HorizontalCourseCard course={fundamentalSection.courses[0]} />
+            </div>
+          </div>
+        </section>
+
+        <section className="w-full dark:bg-gray-800 pb-20">
+          <div className="max-w-screen-lg mx-auto">
+            <div className="flex flex-col-reverse lg:flex-row lg:justify-between mt-20 mb-8 relative">
+              <h2 className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left">
+                {layoutSection.title}
+              </h2>
+              <div
+                aria-hidden
+                className="flex flex-col lg:mt-16 mb-8 font-mono text-2xl font-bold leading-[0.9] text-gray-400 dark:text-gray-600 self-center relative z-10 text-right pt-4"
+              >
+                <span className="text-xl">Week </span>
+                02-03
+              </div>
+              <img
+                className="absolute object-fill overflow-visible bg-no-repeat -top-16 right-[20%] sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
+                src={cssGuide.backgroundGrid}
+              />
+            </div>
+            <div className="flex flex-wrap justify-center lg:justify-between lg:flex-nowrap gap-4">
+              <p className="w-[40ch] mb-8 whitespace-pre-wrap mx-auto sm:mx-0">
+                {layoutSection.description}
+              </p>
+              <CssChallengeCard />
+            </div>
+            <div className="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
+              <HorizontalCourseCard
+                course={layoutSection.courses[0]}
+                className="dark:bg-gray-900 bg-gray-50 col-span-4"
+              />
+              <HorizontalCourseCard
+                course={layoutSection.courses[1]}
+                className="dark:bg-gray-900 bg-gray-50 col-span-4"
+              />
+              <HorizontalCourseCard
+                course={layoutSection.courses[2]}
+                className="dark:bg-gray-900 bg-gray-50 col-span-4"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="w-full">
+          <div className="max-w-screen-lg mx-auto">
+            <div className="flex flex-col-reverse lg:flex-row lg:justify-between mt-20 mb-8 relative">
+              <h2 className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left">
+                {modernSection.title}
+              </h2>
+              <div
+                aria-hidden
+                className="flex flex-col lg:mt-16 mb-8 font-mono text-2xl font-bold leading-[0.9] text-gray-400 dark:text-gray-600 self-center relative z-10 text-right pt-4"
+              >
+                <span className="text-xl">Week </span>
+                04-05
+              </div>
+              <img
+                className="absolute object-fill overflow-visible bg-no-repeat -top-16 right-[20%] sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
+                src={cssGuide.backgroundGrid}
+              />
+            </div>
+            <div className="flex flex-wrap justify-center lg:justify-between lg:flex-nowrap gap-4">
+              <p className="w-[40ch] mb-8 whitespace-pre-wrap mx-auto sm:mx-0">
+                {modernSection.description}
+              </p>
+              <HorizontalCourseCard
+                course={modernSection.courses[0]}
+                className=" col-span-4"
+              />
+            </div>
+            <CssChallengeCardFull />
+          </div>
+        </section>
+      </div>
+    </>
+  )
+}
+
+export default JustEnoughCssForModernAppDevelopment
+
+const query = groq`*[_type == 'resource' && type == 'landing-page' && slug.current == 'just-enough-css-for-modern-app-development'][0]{
+  title,
+  'featureImage': images[label == 'feature-image'][0].url,
+  'backgroundGrid': images[label == 'background-grid'][0].url,
+  'weekGrid': images[label == 'week-grid'][0].url,
+  description,
+  'sections': resources[] {
+    title,
+    description,
+    'courses': resources[]->{
+      title,
+      'description': summary,
+      path,
+      byline,
+      path,
+      image,
+      'background': images[label == 'feature-card-background'][0].url,
+      'instructor': collaborators[]->[role == 'instructor'][0]{
+        'name': person->.name
+      },
+    },
+  }
+}`
+
+export async function getStaticProps(context: any) {
+  const cssGuide = await sanityClient.fetch(query)
+
+  return {
+    props: {cssGuide},
+  }
+}

--- a/src/pages/guides/just-enough-css-for-modern-app-development.tsx
+++ b/src/pages/guides/just-enough-css-for-modern-app-development.tsx
@@ -12,6 +12,7 @@ import {Textfit} from 'react-textfit'
 import {HorizontalResourceCard} from 'components/card/new-horizontal-resource-card'
 import Link from 'next/link'
 import {twMerge} from 'tailwind-merge'
+import React from 'react'
 
 const HorizontalCourseCard: React.FC<{
   course: any
@@ -168,6 +169,8 @@ const CssChallengeCardFull = ({challenge}: {challenge: any}) => {
 const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
   cssGuide,
 }) => {
+  const scrollRef = React.useRef<null | HTMLHeadingElement>(null)
+
   const {sections} = cssGuide
   const [fundamentalSection, layoutSection, modernSection] = sections
 
@@ -223,14 +226,24 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
               </p>
             </div>
           </div>
-          <div className="p-2 mx-auto mt-20 sm:mt-32 rounded-full  w-fit bg-gray-50 dark:bg-opacity-20 dark:text-gray-200 relative z-10">
-            <ArrowDownIcon className="w-5 h-5 text-gray-900 dark:text-white" />
+
+          <div className="p-2 mx-auto mt-20 sm:mt-32 rounded-full  w-fit bg-gray-50 dark:bg-opacity-20 dark:text-gray-200 hover:bg-gray-100 relative z-10 cursor-pointer transition-all hover:scale-110">
+            <ArrowDownIcon
+              className="w-5 h-5 text-gray-900 dark:text-white "
+              onClick={() =>
+                scrollRef?.current &&
+                scrollRef?.current.scrollIntoView({behavior: 'smooth'})
+              }
+            />
           </div>
         </header>
         <section className="w-full pb-20">
           <div className="max-w-screen-lg mx-auto">
             <div className="flex flex-col-reverse lg:flex-row lg:justify-between mt-20 mb-8 relative">
-              <h2 className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left">
+              <h2
+                className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left"
+                ref={scrollRef}
+              >
                 {fundamentalSection.title}
               </h2>
               <div

--- a/src/pages/guides/just-enough-css-for-modern-app-development.tsx
+++ b/src/pages/guides/just-enough-css-for-modern-app-development.tsx
@@ -260,7 +260,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
                 01
               </div>
               <img
-                className="absolute object-fill overflow-visible bg-no-repeat -top-20 right-[20%] sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
+                className="absolute object-fill overflow-visible bg-no-repeat -top-20 right-1/4 sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
                 src={cssGuide.backgroundGrid}
               />
             </div>
@@ -274,7 +274,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
           </div>
         </section>
 
-        <section className="w-full dark:bg-gray-800 bg-gray-50 pb-20">
+        <section className="w-full pt-2 dark:bg-gray-800 bg-gray-50 pb-20">
           <div className="max-w-screen-lg mx-auto">
             <div className="flex flex-col-reverse lg:flex-row lg:justify-between mt-20 mb-8 relative">
               <h2 className="lg:mt-20 lg:mb-8 font-medium text-2xl text-center lg:text-left">
@@ -288,7 +288,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
                 02-03
               </div>
               <img
-                className="absolute object-fill overflow-visible bg-no-repeat -top-16 right-[20%] sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
+                className="absolute object-fill overflow-visible bg-no-repeat -top-16 right-1/4 sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
                 src={cssGuide.backgroundGrid}
               />
             </div>
@@ -329,7 +329,7 @@ const JustEnoughCssForModernAppDevelopment: React.FC<{cssGuide: any}> = ({
                 04-05
               </div>
               <img
-                className="absolute object-fill overflow-visible bg-no-repeat -top-16 right-[20%] sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
+                className="absolute object-fill overflow-visible bg-no-repeat -top-16 right-1/4 sm:right-1/3 lg:-right-16 lg:-top-0 w-60 lg:w-64"
                 src={cssGuide.backgroundGrid}
               />
             </div>

--- a/src/pages/projects/build-modern-layouts-with-css-grid/index.tsx
+++ b/src/pages/projects/build-modern-layouts-with-css-grid/index.tsx
@@ -166,7 +166,7 @@ const landingPage: FunctionComponent<LandingProps> = (props) => {
               <section className="relative mt-16 mb-16 ml-0 mr-0 dark:text-gray-200 md:-ml-28 md:-mr-28">
                 <div className="grid grid-cols-1 gap-5 mt-16 mb-16 lg:grid-cols-2">
                   <div className="relative mb-8 text-center md:mb-0">
-                    <div className="relative z-20 p-4 text-center bg-white shadow-lg dark:bg-gray-800 rounded-xl md:p-8">
+                    <div className="relative z-20 p-4 text-center bg-white shadow-lg dark:bg-gray-800 rounded-xl md:p-8 h-full">
                       <Markdown className="pt-2 mt-0 text-sm leading-normal prose text-left text-gray-800 dark:prose-dark dark:prose-a:text-blue-300 prose-a:text-blue-500 sm:text-base dark:text-gray-200">
                         {pricingPageChallenge.text}
                       </Markdown>


### PR DESCRIPTION
Loom walk through: https://www.loom.com/share/2d09fc12574b432fb039ac0fbf024500

This converts a Learner interview guide into a landing page that we can share more broadly. Content is stored in Sanity so it can be easily updated.

I made the landing page from scratch and recreated simple course and challenge cards

I have yet to do any internal linking to this page so we would need to do that as well. Likely on the Home, CSS, and React pages

![woo](https://media.giphy.com/media/yoJC2GnSClbPOkV0eA/giphy.gif)

(I need to disable an extension for screenshots, ignore the little icon on the right side)
![Just enough CSS for Modern App Development  - desktop](https://github.com/skillrecordings/egghead-next/assets/6188161/c80e3b51-12d8-436b-ab66-8a025da22969)
![Just enough CSS for Modern App Development - mobile](https://github.com/skillrecordings/egghead-next/assets/6188161/dae873c3-5267-4e01-9982-e580e54cf912)
