### PR TITLE
fix: properly apply object-cover to resource card

### DIFF
--- a/src/components/card/new-horizontal-resource-card.tsx
+++ b/src/components/card/new-horizontal-resource-card.tsx
@@ -184,7 +184,6 @@ const PreviewImage: React.FC<{title: string; image: any; name: string}> = ({
         'max-w-[40px]': name === 'lesson',
         'max-w-[80px]': name === 'talk',
         'xl:max-w-[200px] sm:max-w-[150px] max-w-[100px]': name === 'course',
-        'object-cover': name === 'article',
       })}`}
     >
       <Image
@@ -192,6 +191,7 @@ const PreviewImage: React.FC<{title: string; image: any; name: string}> = ({
         src={get(image, 'src', image)}
         width={getSize(name)}
         height={getSize(name)}
+        objectFit={name === 'article' ? 'cover' : 'contain'}
         quality={100}
         alt=""
       />


### PR DESCRIPTION
We weren't properly applying `object-cover` to the horizontal resource card for articles so this card image was getting smooshed. 

I spot checked other pages to make sure the resource card was displaying as expected but worth a second pair of eyes there

![smooshed](https://media1.giphy.com/media/QvBjx0wOsCXbq/giphy.gif?cid=1927fc1blxtnjwjnv1proj73wm8x32b66je59v9kqgvzigz8&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## before
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/8566c06f-5aa6-44a6-9328-1768be1f50ed)

## after
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/4e05a626-3612-4ab2-924d-6c6b37fd89df)
