### PR TITLE
fix: use horizontal card for sign resource

### DIFF
--- a/src/components/mdx/resource-widget.tsx
+++ b/src/components/mdx/resource-widget.tsx
@@ -346,7 +346,7 @@ const ResourceWidget: React.FC<{
               switch (articles.length) {
                 case 1: {
                   return (
-                    <HorizontalResourceCardForWidget
+                    <HorizontalResourceCard
                       location={location}
                       className="col-span-3 md:col-span-4 dark:bg-gray-600 rounded-md"
                       key={article.slug}


### PR DESCRIPTION

## before
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/2e3acc8a-dc4b-4986-a085-6acced4e7a84)


## after
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/6dc9cd41-15fe-41c6-b977-10ea033c8738)


![fix it](https://media1.giphy.com/media/UZuAr03kNcTL71bTWj/giphy.gif?cid=1927fc1b9u5q0c4ionuwfcjf2ah7r0fijojfwsvzakfvb9ek&ep=v1_gifs_search&rid=giphy.gif&ct=g)