### PR TITLE
feat: article series list for the blog

### DIFF
--- a/src/components/mdx/article-series-list.tsx
+++ b/src/components/mdx/article-series-list.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import {useRouter} from 'next/router'
+import cx from 'classnames'
+
+const ArticleSeriesList: React.FC<{
+  resource: any
+  cta?: string
+  location?: string
+}> = ({resource, location}: any) => {
+  const {articles} = resource
+  const router = useRouter()
+
+  return (
+    <div className="border dark:border-gray-700 border-gray-200  rounded p-8">
+      <h2 className=" text-2xl">{resource.title}</h2>
+      <p className="prose my-2 dark:prose-dark ">{resource.description}</p>
+      <hr className="dark:border-gray-700 border-gray-200"></hr>
+      <ul className="flex flex-col mt-2">
+        {articles.map((article: any, i: number) => {
+          return (
+            <Link href={article.path}>
+              <a
+                className={cx('flex gap-4 group hover:text-blue-500 w-fit', {
+                  'font-bold underline': article.path === router.asPath,
+                })}
+              >
+                <span
+                  className={cx(
+                    'text-2xl self-center font-mono group-hover:underline',
+                    {
+                      'font-black': article.path === router.asPath,
+                    },
+                  )}
+                >
+                  {i + 1}
+                </span>
+                <h3 className="text-xl self-center">{article.title}</h3>
+              </a>
+            </Link>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default ArticleSeriesList

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -12,6 +12,7 @@ import CodeBlock from './code-block'
 import ArticleCourseCard from 'components/blog/article-course-card'
 import ArticleTalkCard from 'components/blog/article-talk-card'
 import TopicInterestEmailEntryForm from './topic-interest-form'
+import ArticleSeriesList from './article-series-list'
 // @ts-ignore
 import {TwitterTweetEmbed} from 'react-twitter-embed'
 
@@ -29,6 +30,7 @@ const mdxComponents = {
   DefaultLayout,
   ArticleCourseCard,
   ArticleTalkCard,
+  ArticleSeriesList,
   TopicInterestEmailEntryForm,
   pre: (props: any) => (
     <CodeBlock

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -13,6 +13,7 @@ import {useRouter} from 'next/router'
 import {withProse} from 'utils/remark/with-prose'
 import CourseWidget from 'components/mdx/course-widget'
 import ResourceWidget from 'components/mdx/resource-widget'
+import ArticleSeriesList from 'components/mdx/article-series-list'
 import find from 'lodash/find'
 import {useScrollTracker} from 'react-scroll-tracker'
 import analytics from 'utils/analytics'
@@ -118,6 +119,21 @@ const Tag = (props: any) => {
                   return resource ? (
                     <div className="not-prose my-8">
                       <ResourceWidget
+                        resource={resource}
+                        location={resource.location}
+                        {...props}
+                      />
+                    </div>
+                  ) : null
+                },
+                ArticleSeriesList: ({
+                  resource: resourceSlug,
+                  ...props
+                }: any) => {
+                  const resource = find(articleResources, {slug: resourceSlug})
+                  return resource ? (
+                    <div className="not-prose my-8">
+                      <ArticleSeriesList
                         resource={resource}
                         location={resource.location}
                         {...props}


### PR DESCRIPTION
https://www.loom.com/share/0cdeebc2e6d14bb1bfb4cccd54c4db64

Simple article series component that links to each article in the series and highlights the current article you are on. The annoying part here is you have to create an embedded resource on each article so a bit of copy pasta goes on.

![article-series-list](https://github.com/skillrecordings/egghead-next/assets/6188161/009456d6-3769-4a1f-9967-966e5ddc1913)


![gm](https://media.giphy.com/media/9lEGNc2hPkmevAciHq/giphy-downsized.gif)