### PR TITLE
bug: infinite redirect when sanity course slug != to actual course slug

### DIFF
--- a/src/pages/courses/[slug]/index.tsx
+++ b/src/pages/courses/[slug]/index.tsx
@@ -115,8 +115,8 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   try {
     const course = params && (await loadPlaylist(params.slug as string))
-
-    if (course && course?.slug !== params?.slug) {
+    console.log({req})
+    if (course && course?.path !== req.url) {
       return {
         redirect: {
           destination: course.path,

--- a/src/pages/courses/[slug]/index.tsx
+++ b/src/pages/courses/[slug]/index.tsx
@@ -115,7 +115,6 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   try {
     const course = params && (await loadPlaylist(params.slug as string))
-    console.log({req})
     if (course && course?.path !== req?.url) {
       return {
         redirect: {

--- a/src/pages/courses/[slug]/index.tsx
+++ b/src/pages/courses/[slug]/index.tsx
@@ -116,7 +116,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   try {
     const course = params && (await loadPlaylist(params.slug as string))
     console.log({req})
-    if (course && course?.path !== req.url) {
+    if (course && course?.path !== req?.url) {
       return {
         redirect: {
           destination: course.path,


### PR DESCRIPTION
The slug that is generated in sanity is not based on rails data. When a sanity course document has had it's slug generated on the sanity side (an indeterminate number of courses...) this causes an infinite loop because we have a check `(course && course?.slug !== params.slug)` that retries when the check fails. 

I'm not sure why this behavior changed from before other than having to do with Next/React upgrades..

This fix prefers the course path which is always generated from the rails object.

![g checked](https://media4.giphy.com/media/l4FGp7yJRMJLPsXuw/giphy.gif?cid=1927fc1bramrjbg2ct8jw5zlcxn54wmz899pcogwtm40i793&ep=v1_gifs_search&rid=giphy.gif&ct=g)