### PR TITLE
Remove course download

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -11,7 +11,6 @@ import {NextSeo} from 'next-seo'
 import removeMarkdown from 'remove-markdown'
 import {track} from 'utils/analytics'
 import analytics from 'utils/analytics'
-import FolderDownloadIcon from '../icons/folder-download'
 import RSSIcon from '../icons/rss'
 import {convertTimeWithTitles} from 'utils/time-utils'
 import ClockIcon from '../icons/clock'
@@ -216,7 +215,6 @@ const CollectionPageLayout: React.FunctionComponent<
     watched_count,
     description,
     rss_url,
-    download_url,
     toggle_favorite_url,
     duration,
     collection_progress,
@@ -606,32 +604,6 @@ const CollectionPageLayout: React.FunctionComponent<
                       </p>
                     </LoginForm>
                   </DialogButton>
-                )}
-
-                {/* Download button */}
-                {download_url ? (
-                  <Link
-                    href={download_url}
-                    onClick={() => {
-                      analytics.events.activityCtaClick(
-                        'course download',
-                        slug,
-                        name,
-                      )
-                    }}
-                  >
-                    <div className="flex flex-row items-center px-4 py-2 text-sm text-gray-600 transition-colors ease-in-out bg-white border border-gray-300 rounded shadow-sm dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 dark:bg-gray-800 dark:border-gray-600 xs:text-base">
-                      <FolderDownloadIcon className="w-4 h-4 mr-1" /> Download
-                    </div>
-                  </Link>
-                ) : state === 'retired' ? null : (
-                  <MembershipDialogButton
-                    buttonText="Download"
-                    title="Become a member to download this course"
-                  >
-                    As an egghead member you can download any of our courses and
-                    watch them offline.
-                  </MembershipDialogButton>
                 )}
 
                 {/* RSS button */}

--- a/src/components/layouts/multi-module-collection-page-layout.tsx
+++ b/src/components/layouts/multi-module-collection-page-layout.tsx
@@ -12,7 +12,6 @@ import removeMarkdown from 'remove-markdown'
 import {useViewer} from 'context/viewer-context'
 import {track} from 'utils/analytics'
 import analytics from 'utils/analytics'
-import FolderDownloadIcon from '../icons/folder-download'
 import RSSIcon from '../icons/rss'
 import {convertTimeWithTitles} from 'utils/time-utils'
 import ClockIcon from '../icons/clock'
@@ -214,7 +213,6 @@ const MultiModuleCollectionPageLayout: React.FunctionComponent<
     watched_count,
     description,
     rss_url,
-    download_url,
     toggle_favorite_url,
     duration,
     collection_progress,

--- a/src/components/layouts/php-collection-page-layout.tsx
+++ b/src/components/layouts/php-collection-page-layout.tsx
@@ -10,7 +10,6 @@ import {get, first, filter, isEmpty} from 'lodash'
 import {NextSeo} from 'next-seo'
 import removeMarkdown from 'remove-markdown'
 import {track} from 'utils/analytics'
-import FolderDownloadIcon from '../icons/folder-download'
 import RSSIcon from '../icons/rss'
 import {convertTimeWithTitles} from 'utils/time-utils'
 import CheckIcon from '../icons/check'
@@ -280,7 +279,6 @@ const PhpCollectionPageLayout: React.FunctionComponent<
     watched_count,
     description,
     rss_url,
-    download_url,
     toggle_favorite_url,
     duration,
     collection_progress,
@@ -594,30 +592,6 @@ const PhpCollectionPageLayout: React.FunctionComponent<
                         </p>
                       </LoginForm>
                     </DialogButton>
-                  )}
-
-                  {/* Download button */}
-                  {download_url ? (
-                    <Link
-                      href={download_url}
-                      onClick={() => {
-                        track(`clicked download course`, {
-                          course: course.slug,
-                        })
-                      }}
-                    >
-                      <div className="flex flex-row items-center px-4 py-2 text-sm text-gray-600 transition-colors ease-in-out bg-white border border-gray-300 rounded shadow-sm dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 dark:bg-gray-800 dark:border-gray-600 xs:text-base">
-                        <FolderDownloadIcon className="w-4 h-4 mr-1" /> Download
-                      </div>
-                    </Link>
-                  ) : (
-                    <MembershipDialogButton
-                      buttonText="Download"
-                      title="Become a member to download this course"
-                    >
-                      As an egghead member you can download any of our courses
-                      and watch them offline.
-                    </MembershipDialogButton>
                   )}
 
                   {/* RSS button */}

--- a/src/components/layouts/scrimba-course-layout.tsx
+++ b/src/components/layouts/scrimba-course-layout.tsx
@@ -229,7 +229,6 @@ const ScrimbaPageLayout: React.FunctionComponent<
     watched_count,
     description,
     rss_url,
-    download_url,
     toggle_favorite_url,
     duration,
     collection_progress,

--- a/src/components/pages/landing/membership-benefits/index.tsx
+++ b/src/components/pages/landing/membership-benefits/index.tsx
@@ -11,10 +11,6 @@ const features = [
     description: 'Priority customer support and assistance',
   },
   {
-    icon: 'offline',
-    description: 'Downloadable videos to watch offline',
-  },
-  {
     icon: 'code',
     description: 'Code examples for every lesson',
   },

--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -136,7 +136,6 @@ const PlanIntervalsSwitch: React.FunctionComponent<
 
 const DEFAULT_FEATURES = [
   'Full access to all the premium courses',
-  'Download courses for offline viewing',
   'Closed captions for every video',
   'Commenting and support',
   'Enhanced Transcripts',

--- a/src/components/pro-member-features.tsx
+++ b/src/components/pro-member-features.tsx
@@ -4,7 +4,6 @@ const FeaturesList = () => (
   <ul>
     {[
       'Full access to all the premium courses',
-      'Download courses for offline viewing',
       'Closed captions for every video',
       'Commenting and support',
       'Enhanced Transcripts',

--- a/src/lib/playlists.ts
+++ b/src/lib/playlists.ts
@@ -110,7 +110,6 @@ export async function loadAuthedPlaylistForUser(slug: string) {
       playlist(slug: $slug) {
         favorited
         toggle_favorite_url
-        download_url
         rss_url
       }
     }


### PR DESCRIPTION
This removes course download functionality. I did a find all for the word `download` and removed it from our marketing material. 

Lesson download functionality is still present.

![g download](https://media4.giphy.com/media/l71kleRwrkxxK/giphy.gif?cid=1927fc1bx9y6qf631uqngasnl90btzamz27c4i1ns33aot8e&ep=v1_gifs_search&rid=giphy.gif&ct=g)