### PR TITLE
fix: loading of standalone lessons

### DIFF
--- a/src/hooks/next-data-sections.tsx
+++ b/src/hooks/next-data-sections.tsx
@@ -1,12 +1,12 @@
 import fetcher from 'utils/fetcher'
-import {get} from 'lodash'
+import get from 'lodash/get'
 import useSWR from 'swr'
 
 export const useNextForCollectionSection = (
   collection: any,
   currentItemSlug: string,
 ) => {
-  const lessonsList: any[] = collection.sections?.reduce(
+  const lessonsList: any[] = collection?.sections?.reduce(
     (acc: any[], cur: any) => {
       return [...acc, ...cur.lessons]
     },


### PR DESCRIPTION
fixes following error which caused standalone lessons to error out

![Group 5](https://github.com/skillrecordings/egghead-next/assets/25487857/faedd8b8-8888-42e0-89d1-d5f7d372d0fb)


<img src="https://media.giphy.com/media/Vab5J4WPoaCZWrJLQH/giphy.gif" alt="gif" width="300">