### PR TITLE
feat: show related lessons by primary tag if not in course

### DIFF
--- a/src/components/pages/lessons/collection-lessons-list.tsx
+++ b/src/components/pages/lessons/collection-lessons-list.tsx
@@ -22,16 +22,17 @@ type NextUpListProps = {
 
 const CollectionLessonsList: FunctionComponent<
   React.PropsWithChildren<NextUpListProps>
-> = ({course, currentLessonSlug, progress, onActiveTab}) => {
-  const {lessons} = course
+> = ({course, currentLessonSlug, progress, onActiveTab, lessons}) => {
   const [activeElement, setActiveElement] = React.useState(currentLessonSlug)
   const scrollableNodeRef: any = React.createRef()
+
+  const lessonList = course ? course.lessons : lessons
 
   const AccordionLessonList = () => {
     const [openLesson, setOpenLesson] = React.useState<string[]>([])
 
     React.useEffect(() => {
-      const currentLessonSectionIndex = course.sections?.findIndex(
+      const currentLessonSectionIndex = course?.sections?.findIndex(
         (section: SectionResource) =>
           section.lessons.some((lesson) => lesson.slug === currentLessonSlug),
       )
@@ -52,7 +53,7 @@ const CollectionLessonsList: FunctionComponent<
           value={openLesson}
           onValueChange={handleAccordionChange}
         >
-          {course.sections?.map((section: SectionResource, index: number) => (
+          {course?.sections?.map((section: SectionResource, index: number) => (
             <Accordion.Item key={index} value={`resource_${index}`}>
               <Accordion.Header className="relative z-10 overflow-hidden ">
                 <Accordion.Trigger className="bg-gray-100 group relative z-10 flex w-full items-center justify-between  border border-white/5 dark:bg-gray-800/20 px-3 py-2.5 text-left shadow-lg transition dark:hover:bg-gray-800/40">
@@ -120,7 +121,7 @@ const CollectionLessonsList: FunctionComponent<
     }
   }, [activeElement, setActiveElement, currentLessonSlug])
 
-  return lessons ? (
+  return lessonList ? (
     <div className="h-full overflow-hidden">
       <div className="overflow-hidden bg-gray-100 dark:bg-gray-1000 dark:border-gray-800 h-96 lg:h-full">
         <SimpleBar
@@ -129,10 +130,10 @@ const CollectionLessonsList: FunctionComponent<
           scrollableNodeProps={{ref: scrollableNodeRef}}
         >
           <ol className="h-full md:max-h-[350px] lg:max-h-full max-h-[300px]">
-            {course.sections ? (
+            {course?.sections ? (
               <AccordionLessonList />
             ) : (
-              lessons.map((lesson: LessonResource, index = 0) => {
+              lessonList.map((lesson: LessonResource, index = 0) => {
                 const completedLessons = get(
                   progress,
                   'completed_lessons',

--- a/src/lib/lessons.ts
+++ b/src/lib/lessons.ts
@@ -180,6 +180,36 @@ export async function loadLesson(
 // - dash_url - not used
 // - staff_notes_url - not used
 
+export async function loadAssociatedLessonsByTag(tag: string, token?: string) {
+  const graphQLClient = getGraphQLClient(token)
+
+  try {
+    const {lessons} = await graphQLClient.request(
+      loadAssociatedLessonsByTagQuery,
+      {tag},
+    )
+
+    return lessons
+  } catch (e) {
+    throw e
+  }
+}
+
+const loadAssociatedLessonsByTagQuery = /* GraphQL */ `
+  query getAssociatedLessonsByTag($tag: String!) {
+    lessons(tag: $tag, per_page: 20) {
+      id
+      slug
+      completed
+      title
+      description
+      duration
+      free_forever
+      path
+    }
+  }
+`
+
 const loadLessonGraphQLQuery = /* GraphQL */ `
   query getLesson($slug: String!) {
     lesson(slug: $slug) {
@@ -206,6 +236,12 @@ const loadLessonGraphQLQuery = /* GraphQL */ `
       state
       repo_url
       code_url
+      primary_tag {
+        name
+        label
+        http_url
+        image_url
+      }
       created_at
       updated_at
       published_at

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -10,6 +10,7 @@ import {instructorRouter} from './instructor'
 import {topicRouter} from './topics'
 import {customerIORouter} from './customer-io'
 import {tipsRouter} from './tips'
+import {lessonRouter} from './lesson'
 
 export const appRouter = router({
   healthcheck: baseProcedure.query(() => 'yay!'),
@@ -20,7 +21,8 @@ export const appRouter = router({
   progress: progressRouter,
   topics: topicRouter,
   customerIO: customerIORouter,
-  tips: tipsRouter
+  tips: tipsRouter,
+  lesson: lessonRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/trpc/routers/lesson.ts
+++ b/src/trpc/routers/lesson.ts
@@ -1,0 +1,25 @@
+import {router, baseProcedure} from '../trpc.server'
+import {z} from 'zod'
+import {loadAssociatedLessonsByTag} from 'lib/lessons'
+
+export const lessonRouter = router({
+  getAssociatedLessonsByTag: baseProcedure
+    .input(
+      z.object({
+        tag: z.string(),
+        currentLessonSlug: z.string().optional(),
+      }),
+    )
+    .query(async ({input, ctx}) => {
+      const {tag, currentLessonSlug} = input
+
+      let data = await loadAssociatedLessonsByTag(tag)
+      const filteredData = currentLessonSlug
+        ? data.filter(
+            (lesson: {slug: string}) => lesson.slug !== currentLessonSlug,
+          )
+        : data
+
+      return filteredData
+    }),
+})


### PR DESCRIPTION
The lesson list on the lesson page will now populate with related lessons via `primary_tag` when no course is present.

This PR depends on the GraphQL API being merged [via this pr](https://github.com/skillrecordings/egghead-rails/pull/5228) 

## no course
![no course](https://github.com/skillrecordings/egghead-next/assets/6188161/c3bd1fb1-16ec-476a-b16c-52d2163fdd43)
## course
![course](https://github.com/skillrecordings/egghead-next/assets/6188161/43802ecc-836e-4bb0-83da-143a0ece725f)

![g chemex](https://media4.giphy.com/media/3o6Ztfg45ZhI9oagxO/giphy.gif?cid=1927fc1bl3fexy2fcxjnolvqlv1noadjuo4k17tpubq2owle&ep=v1_gifs_search&rid=giphy.gif&ct=g)