### PR TITLE
wire up use-mux-player

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,14 +1,18 @@
 'use client'
 
+import {QueryClientProvider, QueryClient} from '@tanstack/react-query'
 import {ViewerProvider} from 'context/viewer-context'
 import {CioProvider} from 'hooks/use-cio'
 import {ThemeProvider} from 'next-themes'
 
 export function Providers({children}: {children: React.ReactNode}) {
+  const queryClient = new QueryClient()
   return (
     <ThemeProvider attribute="class">
       <ViewerProvider>
-        <CioProvider>{children}</CioProvider>
+        <QueryClientProvider client={queryClient}>
+          <CioProvider>{children}</CioProvider>
+        </QueryClientProvider>
       </ViewerProvider>
     </ThemeProvider>
   )

--- a/src/app/tips/[tipId]/page.tsx
+++ b/src/app/tips/[tipId]/page.tsx
@@ -1,8 +1,5 @@
 import {getAllTips, getTip} from 'lib/tips'
-import TipPlayer from 'components/tips/tip-player'
-import {VideoTranscript} from 'components/video/video-transcript'
-import MarkdownCodeblock from 'components/tips/ui/markdown-codeblock'
-import RelatedTips from 'components/tips/related-tips'
+import TipTemplate from 'components/tips/tip-template'
 
 export default async function Tip({params}: {params: {tipId: string}}) {
   const tip = await getTip(params.tipId)
@@ -11,52 +8,7 @@ export default async function Tip({params}: {params: {tipId: string}}) {
   return (
     tip && (
       <>
-        <main className="mx-auto w-full" id="tip">
-          <div className="relative z-10 flex items-center justify-center">
-            <div className="flex w-full max-w-screen-xl flex-col">
-              <div className="flex items-center justify-center overflow-hidden shadow-gray-600/40 sm:shadow-2xl xl:rounded-b-md">
-                <TipPlayer tip={tip} />
-              </div>
-            </div>
-          </div>
-          <article className="relative z-10 border-l border-transparent px-5 pb-16 pt-8 sm:pt-10 xl:border-gray-800 xl:pt-10">
-            <div className="mx-auto w-full max-w-screen-lg pb-5 lg:px-5">
-              <div className="flex w-full grid-cols-5 flex-col gap-0 sm:gap-10 xl:grid">
-                <div className="col-span-3">
-                  <h1 className="leading-tighter inline-flex w-full max-w-2xl items-baseline text-3xl font-black lg:text-3xl">
-                    {tip.title}
-                  </h1>
-
-                  {tip.body && (
-                    <>
-                      <div className="prose w-full max-w-none pb-5 pt-5 dark:prose-invert lg:prose-lg">
-                        <MarkdownCodeblock tip={tip.body} />
-                      </div>
-                      <hr className="bg-indigo-400" />
-                    </>
-                  )}
-                  {tip.transcript && tip.body && (
-                    <div className="w-full max-w-2xl pt-5">
-                      <VideoTranscript transcript={tip.transcript} />
-                    </div>
-                  )}
-                </div>
-                <div className="col-span-2">
-                  {/* TODO: might want to add summary? */}
-                  {tip.body && <RelatedTips currentTip={tip} tips={tips} />}
-                </div>
-              </div>
-            </div>
-            <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-10 sm:pt-10 md:flex-row">
-              {tip.transcript && !tip.body && (
-                <div className="w-full max-w-2xl pt-5">
-                  <VideoTranscript transcript={tip.transcript} />
-                </div>
-              )}
-              {!tip.body && <RelatedTips currentTip={tip} tips={tips} />}
-            </div>
-          </article>
-        </main>
+        <TipTemplate tip={tip} tips={tips} />
       </>
     )
   )

--- a/src/components/tips/tip-player.tsx
+++ b/src/components/tips/tip-player.tsx
@@ -69,7 +69,7 @@ const TipOverlay: React.FC<{tips: Tip[]}> = ({tips}) => {
         {/* <ShareTip lesson={tip} /> */}
         <div className="grid h-full grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
           {take(shuffle(tips), 9).map((tip) => (
-            <VideoOverlayTipCard suggestedTip={tip} />
+            <VideoOverlayTipCard suggestedTip={tip} key={tip.slug} />
           ))}
         </div>
       </div>

--- a/src/components/tips/tip-player.tsx
+++ b/src/components/tips/tip-player.tsx
@@ -1,20 +1,134 @@
 'use client'
 import React from 'react'
-import MuxPlayer, {
-  MuxPlayerProps,
-  MuxPlayerRefAttributes,
-} from '@mux/mux-player-react'
+import MuxPlayer, {MuxPlayerProps} from '@mux/mux-player-react'
+import Image from 'next/legacy/image'
+import {useRouter} from 'next/navigation'
+
+import {XIcon, PlayIcon} from '@heroicons/react/solid'
+import {shuffle, take} from 'lodash'
 import {useMuxPlayer} from 'hooks/mux/use-mux-player'
 import './styles.css'
+import {useVideoResource} from 'hooks/use-video-resource'
+import {Tip} from 'lib/tips'
+import cx from 'classnames'
 
-const TipPlayer: React.FC<{tip: any}> = ({tip}) => {
-  const muxPlayerRef = React.useRef<MuxPlayerRefAttributes>(null)
-  const {muxPlayerProps, displayOverlay} = useMuxPlayer()
+const TipPlayer: React.FC<{tip: Tip; tips: Tip[]; ref: any}> = React.forwardRef(
+  ({tip, tips}, ref: any) => {
+    const {muxPlayerProps, displayOverlay} = useMuxPlayer()
+    const {videoResource} = useVideoResource()
+
+    return (
+      <div className="w-full min-h-[50vh] relative aspect-video">
+        {displayOverlay && <TipOverlay tips={tips} />}
+        <div
+          className={cx('', {
+            hidden: displayOverlay,
+          })}
+        >
+          <MuxPlayer
+            playbackId={tip.muxPlaybackId || videoResource?.muxPlaybackId}
+            ref={ref}
+            {...(muxPlayerProps as MuxPlayerProps)}
+          />
+        </div>
+      </div>
+    )
+  },
+)
+
+const TipOverlay: React.FC<{tips: Tip[]}> = ({tips}) => {
+  const {setDisplayOverlay, handlePlay} = useMuxPlayer()
+
+  const buttonStyles =
+    'py-2 px-3 font-medium rounded flex items-center gap-1 hover:bg-gray-700/50 bg-black/80 transition text-gray-200'
+  return (
+    <div
+      id="video-overlay"
+      className="relative left-0 top-0 flex w-full items-center justify-center bg-[#070B16] lg:aspect-video"
+    >
+      <div className="absolute right-8 top-8 z-50 flex items-center justify-center gap-3">
+        <button className={buttonStyles} onClick={handlePlay}>
+          Replay <span aria-hidden="true">↺</span>
+        </button>
+        <button
+          className={buttonStyles}
+          onClick={() => {
+            // track('dismissed video overlay', {
+            //   lesson: lesson.slug,
+            //   module: module.slug.current,
+            //   moduleType: 'tip',
+            //   lessonType: lesson._type,
+            // })
+            setDisplayOverlay(false)
+          }}
+        >
+          Dismiss <XIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="left-0 top-0 z-20 flex h-full w-full flex-col items-center justify-center p-5 text-center text-lg leading-relaxed lg:absolute">
+        {/* <ShareTip lesson={tip} /> */}
+        <div className="grid h-full grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {take(shuffle(tips), 9).map((tip) => (
+            <VideoOverlayTipCard suggestedTip={tip} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const VideoOverlayTipCard: React.FC<{suggestedTip: Tip}> = ({suggestedTip}) => {
+  const router = useRouter()
+  // const {tipCompleted} = useTipComplete(suggestedTip.slug)
+
+  const thumbnail = `https://image.mux.com/${suggestedTip.muxPlaybackId}/thumbnail.png?width=288&height=162&fit_mode=preserve`
 
   return (
-    <div className="w-full min-h-[50vh]">
-      <MuxPlayer playbackId={tip.muxPlaybackId} />
-    </div>
+    <button
+      key={suggestedTip.slug}
+      onClick={() => {
+        // track('clicked suggested tip thumbnail', {
+        //   lesson: suggestedTip.slug,
+        // })
+        router.push(`/tips/${suggestedTip.slug}`)
+      }}
+      className="group relative z-0 flex aspect-video h-full w-full items-end justify-start rounded-lg bg-gray-900/60 p-8 text-left font-medium leading-tight text-gray-200"
+    >
+      <div className="relative z-10 flex flex-col">
+        <span className="pb-1 font-mono text-xs font-semibold uppercase text-gray-500">
+          Tip
+        </span>
+        <span className="font-medium">
+          {suggestedTip.title}{' '}
+          {/* {tipCompleted && <span className="sr-only">(watched)</span>} */}
+        </span>
+      </div>
+      <Image
+        src={thumbnail}
+        alt=""
+        aria-hidden="true"
+        layout="fill"
+        className="blur-xs z-0 object-cover opacity-30 transition group-hover:opacity-40 group-hover:brightness-150"
+        quality={100}
+      />
+      <div
+        className="absolute left-0 top-0 flex h-full w-full items-start justify-end p-5"
+        aria-hidden="true"
+      >
+        {/* {tipCompleted ? (
+          <>
+            <CheckCircleIcon
+              className="absolute h-10 w-10 text-teal-400 transition group-hover:opacity-0"
+              aria-hidden="true"
+            />
+            <PlayIcon className="h-10 w-10 flex-shrink-0 scale-50 text-teal-400 opacity-0 transition group-hover:scale-100 group-hover:opacity-100" />
+          </>
+        ) : (
+          <PlayIcon className="h-10 w-10 flex-shrink-0 scale-50 text-gray-300 opacity-0 transition group-hover:scale-100 group-hover:opacity-100" />
+        )} */}
+        <PlayIcon className="h-10 w-10 flex-shrink-0 scale-50 text-gray-300 opacity-0 transition group-hover:scale-100 group-hover:opacity-100" />
+      </div>
+    </button>
   )
 }
 

--- a/src/components/tips/tip-template.tsx
+++ b/src/components/tips/tip-template.tsx
@@ -1,0 +1,96 @@
+'use client'
+import React from 'react'
+import {VideoTranscript} from 'components/video/video-transcript'
+import TipPlayer from './tip-player'
+import MarkdownCodeblock from './ui/markdown-codeblock'
+import RelatedTips from './related-tips'
+import {type Tip} from 'lib/tips'
+import {VideoProvider} from 'hooks/mux/use-mux-player'
+import {MuxPlayerRefAttributes} from '@mux/mux-player-react/.'
+import {LessonProvider} from 'hooks/use-lesson'
+import {VideoResourceProvider} from 'hooks/use-video-resource'
+// import {trpc} from 'trpc/trpc.client'
+
+const TipTemplate = ({tip, tips}: {tip: Tip; tips: Tip[]}) => {
+  const muxPlayerRef = React.useRef<MuxPlayerRefAttributes>(null)
+  const handleVideoEnded = async () => {
+    // await localProgressDb.progress
+    //   .add({
+    //     eventName: 'completed video',
+    //     module: 'tips',
+    //     lesson: tip.slug,
+    //     createdOn: new Date(),
+    //   })
+    //   .then(console.debug)
+    console.log('video ended')
+  }
+
+  const module: any = {
+    slug: {
+      current: 'tips',
+    },
+    moduleType: 'tip',
+    lessons: tips,
+    resources: tips.filter((tipToCompare) => tipToCompare.slug !== tip.slug),
+  }
+  return (
+    <LessonProvider lesson={tip} module={module}>
+      <VideoResourceProvider videoResourceId={tip?.videoResourceId || ''}>
+        <VideoProvider
+          muxPlayerRef={muxPlayerRef}
+          onEnded={handleVideoEnded}
+          exerciseSlug={tip.slug}
+          path="/tips"
+        >
+          <main className="mx-auto w-full" id="tip">
+            <div className="relative z-10 flex items-center justify-center">
+              <div className="flex w-full max-w-screen-xl flex-col">
+                <div className="flex items-center justify-center overflow-hidden shadow-gray-600/40 sm:shadow-2xl xl:rounded-b-md">
+                  <TipPlayer tip={tip} tips={tips} ref={muxPlayerRef} />
+                </div>
+              </div>
+            </div>
+            <article className="relative z-10 border-l border-transparent px-5 pb-16 pt-8 sm:pt-10 xl:border-gray-800 xl:pt-10">
+              <div className="mx-auto w-full max-w-screen-lg pb-5 lg:px-5">
+                <div className="flex w-full grid-cols-5 flex-col gap-0 sm:gap-10 xl:grid">
+                  <div className="col-span-3">
+                    <h1 className="leading-tighter inline-flex w-full max-w-2xl items-baseline text-3xl font-black lg:text-3xl">
+                      {tip.title}
+                    </h1>
+                    {tip.body && (
+                      <>
+                        <div className="prose w-full max-w-none pb-5 pt-5 dark:prose-invert lg:prose-lg">
+                          <MarkdownCodeblock tip={tip.body} />
+                        </div>
+                        <hr className="bg-indigo-400" />
+                      </>
+                    )}
+                    {tip.transcript && tip.body && (
+                      <div className="w-full max-w-2xl pt-5">
+                        <VideoTranscript transcript={tip.transcript} />
+                      </div>
+                    )}
+                  </div>
+                  <div className="col-span-2">
+                    {/* TODO: might want to add summary? */}
+                    {tip.body && <RelatedTips currentTip={tip} tips={tips} />}
+                  </div>
+                </div>
+              </div>
+              <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-10 sm:pt-10 md:flex-row">
+                {tip.transcript && !tip.body && (
+                  <div className="w-full max-w-2xl pt-5">
+                    <VideoTranscript transcript={tip.transcript} />
+                  </div>
+                )}
+                {!tip.body && <RelatedTips currentTip={tip} tips={tips} />}
+              </div>
+            </article>
+          </main>
+        </VideoProvider>
+      </VideoResourceProvider>
+    </LessonProvider>
+  )
+}
+
+export default TipTemplate

--- a/src/hooks/mux/get-next-section.ts
+++ b/src/hooks/mux/get-next-section.ts
@@ -1,0 +1,20 @@
+import find from 'lodash/find'
+import indexOf from 'lodash/indexOf'
+import first from 'lodash/first'
+import {type Section} from 'schemas/section'
+import {type Module} from 'schemas/module'
+
+export const getNextSection = ({
+  module,
+  currentSection,
+}: {
+  module: Module
+  currentSection?: Section
+}) => {
+  const sections = module.sections
+
+  const current = find(sections, {_id: currentSection?._id}) || first(sections)
+  const nextSectionIndex = indexOf(sections, current) + 1
+  const nextSection = sections?.[nextSectionIndex] || null
+  return nextSection
+}

--- a/src/hooks/mux/use-next-lesson.ts
+++ b/src/hooks/mux/use-next-lesson.ts
@@ -1,0 +1,37 @@
+import {useRouter, useSearchParams} from 'next/navigation'
+
+import {type Lesson} from 'schemas/lesson'
+
+// import {trpcSkillLessons} from 'utils/trpc-skill-lessons'
+import {type Section} from 'schemas/section'
+import {type Module} from 'schemas/module'
+
+export const useNextLesson = (
+  lesson: Lesson,
+  module: Module,
+  section?: Section,
+) => {
+  const router = useRouter()
+
+  let slug = lesson.slug
+  const searchParams = useSearchParams()
+  const lessonParam = searchParams?.get('lesson') || ''
+
+  if (lesson._type === 'solution') {
+    slug = lessonParam as string
+  }
+
+  //! tips return undefined so mocking that here
+  // const {data: nextExercise, status: nextExerciseStatus} =
+  //   trpcSkillLessons.lessons.getNextLesson.useQuery({
+  //     type: lesson._type,
+  //     slug,
+  //     module: module.slug.current,
+  //     section: section?.slug,
+  //   })
+
+  const nextExercise = undefined
+  const nextExerciseStatus = undefined
+
+  return {nextExercise, nextExerciseStatus}
+}

--- a/src/hooks/use-lesson.tsx
+++ b/src/hooks/use-lesson.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import {type Lesson} from 'schemas/lesson'
+import {type Section} from 'schemas/section'
+import {type Module} from 'schemas/module'
+
+type LessonContextType = {
+  lesson: Lesson
+  section?: Section
+  module: Module
+}
+
+export const LessonContext = React.createContext({} as LessonContextType)
+
+type LessonProviderProps = {
+  lesson: Lesson
+  module: Module
+  section?: Section
+  children: React.ReactNode
+}
+
+export const LessonProvider: React.FC<LessonProviderProps> = ({
+  lesson,
+  module,
+  section,
+  children,
+}) => {
+  const context = {
+    lesson,
+    module,
+    section,
+  }
+  return (
+    <LessonContext.Provider value={context}>{children}</LessonContext.Provider>
+  )
+}
+
+export const useLesson = () => {
+  const videoResourceContext = React.useContext(LessonContext)
+  return videoResourceContext
+}

--- a/src/hooks/use-video-resource.tsx
+++ b/src/hooks/use-video-resource.tsx
@@ -1,7 +1,11 @@
+import {useQuery} from '@tanstack/react-query'
+import {getVideoResource} from 'lib/video-resources'
 import * as React from 'react'
+import {type VideoResource} from 'schemas/video-resource'
+import {trpc} from 'trpc/trpc.client'
 
 type VideoResourceContextType = {
-  videoResource?: any
+  videoResource?: VideoResource
   loadingVideoResource: boolean
   videoResourceId: string
 }
@@ -15,12 +19,22 @@ type VideoResourceProviderProps = {
   children: React.ReactNode
 }
 
+const useVideoResourceData = (id: string) => {
+  return useQuery(['video-resource'], async () => {
+    if (id) {
+      return await getVideoResource(id)
+    }
+  })
+}
+
 export const VideoResourceProvider: React.FC<VideoResourceProviderProps> = ({
   videoResourceId,
   children,
 }) => {
+  const {data: videoResource, status} = useVideoResourceData(videoResourceId)
+  // trpc with app router is in a huge flux right now, opting for react-query
   // const {data: videoResource, status} =
-  //   trpcSkillLessons.videoResource.byId.useQuery(
+  //   trpc.videoResource.byId.useQuery(
   //     {id: videoResourceId},
   //     {
   //       refetchOnWindowFocus: false,
@@ -29,8 +43,8 @@ export const VideoResourceProvider: React.FC<VideoResourceProviderProps> = ({
 
   const context = {
     videoResourceId,
-    // videoResource,
-    loadingVideoResource: false, //status === 'loading',
+    videoResource,
+    loadingVideoResource: status === 'loading',
   }
   return (
     <VideoResourceContext.Provider value={context}>

--- a/src/lib/video-resources.ts
+++ b/src/lib/video-resources.ts
@@ -1,0 +1,16 @@
+import groq from 'groq'
+import {type VideoResource, VideoResourceSchema} from 'schemas/video-resource'
+import {sanityClient} from 'utils/sanity-client'
+
+export const getVideoResource = async (id: string): Promise<VideoResource> => {
+  const videoResource = await sanityClient.fetch(
+    groq`*[_type in ['videoResource'] && _id == $id][0]{
+      _id,
+      "transcript": transcript.text,
+      "muxPlaybackId": muxAsset.muxPlaybackId
+    }`,
+    {id},
+  )
+
+  return VideoResourceSchema.parse(videoResource)
+}

--- a/src/schemas/collection.ts
+++ b/src/schemas/collection.ts
@@ -1,0 +1,10 @@
+import z from 'zod'
+import {ResourceSchema} from './resource'
+
+export const CollectionSchema = z
+  .object({
+    resources: z.array(ResourceSchema).nullish(),
+  })
+  .merge(ResourceSchema)
+
+export type Collection = z.infer<typeof CollectionSchema>

--- a/src/schemas/exercise.ts
+++ b/src/schemas/exercise.ts
@@ -1,0 +1,11 @@
+import {ResourceSchema} from './resource'
+import z from 'zod'
+import {LessonResourceSchema} from './lesson'
+
+export const ExerciseSchema = z
+  .object({
+    solution: z.nullable(LessonResourceSchema.optional()),
+  })
+  .merge(ResourceSchema)
+
+export type Exercise = z.infer<typeof ExerciseSchema>

--- a/src/schemas/lesson.ts
+++ b/src/schemas/lesson.ts
@@ -1,0 +1,13 @@
+import z from 'zod'
+
+import {ResourceSchema} from './resource'
+
+export const LessonResourceSchema = z
+  .object({
+    _id: z.string().optional(),
+    _key: z.string().optional(),
+    resources: z.array(ResourceSchema).nullish(),
+  })
+  .merge(ResourceSchema)
+
+export type Lesson = z.infer<typeof LessonResourceSchema>

--- a/src/schemas/module.ts
+++ b/src/schemas/module.ts
@@ -1,0 +1,37 @@
+import z from 'zod'
+import {LessonResourceSchema} from './lesson'
+import {ExerciseSchema} from './exercise'
+import {CollectionSchema} from './collection'
+import {SectionSchema} from './section'
+import {TestimonialSchema} from './testimonial'
+
+export const ModuleSchema = z
+  .object({
+    _id: z.string().optional(),
+    moduleType: z.string(),
+    ogImage: z.string().nullish(),
+    image: z.string().nullish(),
+    product: z.object({productId: z.string()}).nullish(),
+    cta: z
+      .object({
+        body: z.array(z.any()).or(z.string()).nullish(),
+        expiresAt: z.string().nullish(),
+      })
+      .nullish(),
+    github: z
+      .object({
+        repo: z.string().nullish(),
+      })
+      .nullish(),
+    slug: z.object({
+      current: z.string().nullish(),
+    }),
+    lessons: z
+      .array(z.intersection(LessonResourceSchema, ExerciseSchema))
+      .nullish(),
+    sections: z.array(SectionSchema).nullish(),
+    testimonials: z.array(TestimonialSchema).nullish(),
+  })
+  .merge(CollectionSchema.omit({slug: true}))
+
+export type Module = z.infer<typeof ModuleSchema>

--- a/src/schemas/resource.ts
+++ b/src/schemas/resource.ts
@@ -1,0 +1,13 @@
+import z from 'zod'
+
+export const ResourceSchema = z.object({
+  _type: z.string(),
+  _updatedAt: z.string().optional(),
+  title: z.string(),
+  slug: z.string(),
+  videoResourceId: z.nullable(z.string().optional()),
+  description: z.nullable(z.string()).optional(),
+  body: z.nullable(z.any().array().optional().or(z.string().optional())),
+})
+
+export type Resource = z.infer<typeof ResourceSchema>

--- a/src/schemas/section.ts
+++ b/src/schemas/section.ts
@@ -1,0 +1,15 @@
+import z from 'zod'
+import {LessonResourceSchema} from './lesson'
+import {ExerciseSchema} from './exercise'
+import {CollectionSchema} from './collection'
+
+export const SectionSchema = z
+  .object({
+    _id: z.string().optional(),
+    lessons: z
+      .array(z.intersection(LessonResourceSchema, ExerciseSchema))
+      .nullish(),
+  })
+  .merge(CollectionSchema)
+
+export type Section = z.infer<typeof SectionSchema>

--- a/src/schemas/testimonial.ts
+++ b/src/schemas/testimonial.ts
@@ -1,0 +1,14 @@
+import z from 'zod'
+
+export const TestimonialSchema = z.object({
+  _id: z.string(),
+  _type: z.string(),
+  _updatedAt: z.string().optional(),
+  body: z.nullable(z.any().array().optional()),
+  author: z.object({
+    name: z.string().optional(),
+    image: z.string().optional(),
+  }),
+})
+
+export type Testimonial = z.infer<typeof TestimonialSchema>

--- a/src/schemas/video-resource.ts
+++ b/src/schemas/video-resource.ts
@@ -1,0 +1,9 @@
+import z from 'zod'
+
+export const VideoResourceSchema = z.object({
+  _id: z.string().optional(),
+  muxPlaybackId: z.string().optional(),
+  transcript: z.nullable(z.any().array().or(z.string())).optional(),
+})
+
+export type VideoResource = z.infer<typeof VideoResourceSchema>

--- a/src/utils/video/default-handle-continue.ts
+++ b/src/utils/video/default-handle-continue.ts
@@ -1,0 +1,88 @@
+import {type Module} from 'schemas/module'
+import {type Section} from 'schemas/section'
+import {type Exercise} from 'schemas/exercise'
+import {type Lesson} from 'schemas/lesson'
+import {type NextRouter} from 'next/router'
+
+export const defaultHandleContinue = async ({
+  router,
+  module,
+  section,
+  nextExercise,
+  handlePlay,
+  path,
+}: {
+  router: NextRouter
+  module: Module
+  section?: Section | null
+  nextExercise?: Lesson | null
+  handlePlay: () => void
+  path: string
+}) => {
+  if (nextExercise?._type === 'solution') {
+    if (section) {
+      const exercise =
+        section.lessons &&
+        section.lessons.find((exercise: Exercise) => {
+          const solution = exercise.solution
+          return solution?._key === nextExercise._key
+        })
+
+      return (
+        exercise &&
+        // needs to be updated to new router
+        (await router
+          .push({
+            query: {
+              module: module.slug.current,
+              section: section.slug,
+              lesson: exercise.slug,
+            },
+
+            pathname: `${path}/[module]/[section]/[lesson]/solution`,
+          })
+          .then(() => handlePlay()))
+      )
+    } else {
+      const exercise =
+        module.lessons &&
+        module.lessons.find((exercise: Exercise) => {
+          const solution = exercise.solution
+          return solution?._key === nextExercise._key
+        })
+
+      return (
+        exercise &&
+        (await router
+          .push({
+            query: {
+              module: module.slug.current,
+              lesson: exercise.slug,
+            },
+
+            pathname: `${path}/[module]/[lesson]/solution`,
+          })
+          .then(() => handlePlay()))
+      )
+    }
+  }
+  if (section) {
+    return await router
+      .push({
+        query: {
+          module: module.slug.current,
+          section: section.slug,
+          lesson: nextExercise?.slug,
+        },
+        pathname: `${path}/[module]/[section]/[lesson]`,
+      })
+      .then(() => handlePlay())
+  } else {
+    return await router
+      .push({
+        query: {module: module.slug.current, lesson: nextExercise?.slug},
+        pathname: `${path}/[module]/[lesson]`,
+      })
+      .then(() => handlePlay())
+  }
+}

--- a/src/utils/video/handle-play-from-beginning.ts
+++ b/src/utils/video/handle-play-from-beginning.ts
@@ -1,0 +1,58 @@
+import {type NextRouter, useRouter} from 'next/router'
+import {type Section} from 'schemas/section'
+import {type Module} from 'schemas/module'
+
+export const pathnameForPath = ({
+  section,
+  path,
+}: {
+  section?: Section
+  path: string
+}) => {
+  return section
+    ? `/${path}/[module]/[section]/[lesson]`
+    : `/${path}/[module]/[lesson]`
+}
+
+export const getRouteQuery = ({
+  section,
+  module,
+}: {
+  section?: Section
+  module: Module
+}) => {
+  return section
+    ? {
+        module: module.slug.current,
+        section: module.sections && module.sections[0].slug,
+        lesson:
+          module.sections &&
+          module.sections[0].lessons &&
+          module.sections[0].lessons[0].slug,
+      }
+    : {
+        module: module.slug.current,
+        lesson: module.lessons && module.lessons[0].slug,
+      }
+}
+export const handlePlayFromBeginning = ({
+  router,
+  section,
+  module,
+  path,
+  handlePlay = () => {},
+}: {
+  router: NextRouter
+  section?: Section
+  module: Module
+  path: string
+  handlePlay: () => void
+}) => {
+  // needs to be updated to new router
+  return router
+    .push({
+      pathname: pathnameForPath({section, path}),
+      query: getRouteQuery({section, module}),
+    })
+    .then(handlePlay)
+}


### PR DESCRIPTION
This adds in functionality that `use-mux-player` provides like video overlay to select other tips after the tip is watched.


Walk through the work here: 
https://www.loom.com/share/2ba26c2191f24192af357d244c8fbc4f

I could use some help with the CSS of the overlay. Not sure if because we only have two tips up that it looks off but it has room for improvement:

![more tips overlay](https://github.com/skillrecordings/egghead-next/assets/6188161/08cbd6c7-b61c-40e3-b674-368258092680)


![g wires](https://media0.giphy.com/media/3o6MbnG1lpwIf5stB6/giphy.gif?cid=1927fc1beqaakyms5me1zov2r38gnwwruab968en3abvscg0&ep=v1_gifs_search&rid=giphy.gif&ct=g)