### PR TITLE
upgrades @tailwind/forms to remove dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@stripe/react-stripe-js": "^1.4.1",
     "@stripe/stripe-js": "^1.17.1",
     "@supabase/supabase-js": "^1.21.0",
-    "@tailwindcss/forms": "^0.4.0",
+    "@tailwindcss/forms": "^0.5.6",
     "@tailwindcss/line-clamp": "^0.3.0",
     "@tailwindcss/typography": "^0.5.0",
     "@tanem/react-nprogress": "^3.0.77",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,10 +5209,10 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tailwindcss/forms@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.4.1.tgz#5a47ccd60490cbba84e662f2b9cf3d71a5126d17"
-  integrity sha512-gS9xjCmJjUBz/eP12QlENPLnf0tCx68oYE3mri0GMP5jdtVwLbGUNSRpjsp6NzLAZzZy3ueOwrcqB78Ax6Z84A==
+"@tailwindcss/forms@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.6.tgz#29c6c2b032b363e0c5110efed1499867f6d7e868"
+  integrity sha512-Fw+2BJ0tmAwK/w01tEFL5TiaJBX1NLT1/YbWgvm7ws3Qcn11kiXxzNTEQDMs5V3mQemhB56l3u0i9dwdzSQldA==
   dependencies:
     mini-svg-data-uri "^1.2.3"
 


### PR DESCRIPTION
terminal was full of these 'autoprefixer' warnings. This was because `@tailwindcss/forms` needed to update one of its dependencies. after upgrading all these warnings go away

![image](https://github.com/skillrecordings/egghead-next/assets/6188161/da5662a5-efc9-49d4-ad78-a572e5c9799b)


![go away](https://media0.giphy.com/media/ac7MA7r5IMYda/giphy.gif?cid=1927fc1b0u1gb5qbeiu3p02o7z6iuya6g639ja3725hr1or5&ep=v1_gifs_search&rid=giphy.gif&ct=g)