### PR TITLE
Set Video Duration in Sanity by consuming Mux Webhook events in egghead-next

### DIFF
--- a/src/app/api/webhooks/tips/mux/route.ts
+++ b/src/app/api/webhooks/tips/mux/route.ts
@@ -1,0 +1,80 @@
+import {NextRequest, NextResponse} from 'next/server'
+import {headers} from 'next/headers'
+import Mux from '@mux/mux-node'
+import client from '@sanity/client'
+import _get from 'lodash/get'
+import groq from 'groq'
+
+const secret = process.env.MUX_WEBHOOK_SIGNING_SECRET || ''
+
+const sanityClient = client({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
+  useCdn: false,
+  token: process.env.SANITY_EDITOR_TOKEN,
+  apiVersion: '2021-10-21',
+})
+
+const videoResourceQuery = groq`
+  *[_type == 'videoResource' && muxAsset.muxAssetId == $id][0] {
+  _id
+}`
+
+export async function POST(req: NextRequest) {
+  const signature = headers().get('mux-signature') as string
+  const muxRequestBody = await req.json()
+  const isValid = Mux.Webhooks.verifyHeader(
+    JSON.stringify(muxRequestBody),
+    signature,
+    secret,
+  )
+  console.log({isValid, muxRequestBody})
+  try {
+    if (isValid) {
+      console.info(
+        'processing Mux webhook:',
+        muxRequestBody.type,
+        muxRequestBody.id,
+      )
+
+      if (muxRequestBody.type === 'video.asset.ready') {
+        try {
+          const params = {
+            id: muxRequestBody.object.id,
+          }
+
+          const videoResource = await sanityClient.fetch(
+            videoResourceQuery,
+            params,
+          )
+
+          await sanityClient
+            .patch(videoResource._id)
+            .set({
+              duration: muxRequestBody.data.duration,
+            })
+            .commit()
+
+          return NextResponse.json({success: true}, {status: 200})
+        } catch (e) {
+          console.error(e)
+          return NextResponse.json(
+            {error: 'Internal Server Error', success: false},
+            {status: 500},
+          )
+        }
+      } else {
+        return NextResponse.json(
+          {
+            error: `${muxRequestBody.type} currently not handled`,
+            success: false,
+          },
+          {status: 422},
+        )
+      }
+    }
+  } catch (e) {
+    // Sentry.captureException(e)
+    return NextResponse.json({success: true}, {status: 200})
+  }
+}

--- a/src/app/api/webhooks/tips/mux/route.ts
+++ b/src/app/api/webhooks/tips/mux/route.ts
@@ -28,7 +28,6 @@ export async function POST(req: NextRequest) {
     signature,
     secret,
   )
-  console.log({isValid, muxRequestBody})
   try {
     if (isValid) {
       console.info(


### PR DESCRIPTION
This is the second step to tracking views for egghead tips by adding the duration to video assets. Next we will want to add another sanity webhook to sync the tip that had it's video asset duration updated with the rails object that has been created in step 1 (#1375). 

[loom](https://www.loom.com/share/293a1c16e8074667ae744dd41a693a85?sid=35fe0449-6ff5-4bb1-a1cc-c1a52892804e)


![watch](https://media0.giphy.com/media/e06Wc1bfzPQXnXyhLW/giphy.gif?cid=1927fc1b92s3jbpy0uvwhpe73c2j66lwjk7143mnd5e6oa9b&ep=v1_gifs_search&rid=giphy.gif&ct=g)