### PR TITLE
display tips on home page and in header nav

### DIFF
--- a/src/components/app/app-header/index.tsx
+++ b/src/components/app/app-header/index.tsx
@@ -197,11 +197,32 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
     )
   }
 
+  const Tips = () => {
+    return (
+      <Link href={`/tips`}>
+        <a
+          onClick={() =>
+            analytics.events.activityInternalLinkClick(
+              'tips',
+              'header',
+              'tips',
+              '/tips',
+            )
+          }
+          className="flex items-center h-full px-3 dark:hover:bg-white hover:bg-gray-50 dark:hover:bg-opacity-5"
+        >
+          Tips
+        </a>
+      </Link>
+    )
+  }
+
   const MobileNavigation = () => {
     return (
       <ul className="relative z-20 flex flex-col w-full px-3 pb-5 space-y-2 text-base dark:bg-gray-800 bg-gray-50 shadow-smooth">
         {[
           SearchBar,
+          !isEmpty(viewer) && Tips,
           !isEmpty(viewer) && Bookmarks,
           !isEmpty(viewer) && Feedback,
           showTeamNavLink && Team,
@@ -238,6 +259,7 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
               {!md && !isSearch && <SearchBar />}
               {!sm && (
                 <>
+                  {!isEmpty(viewer) && <Tips />}
                   {!isEmpty(viewer) && <Bookmarks />}
                   {!isEmpty(viewer) && <Feedback />}
                   {showTeamNavLink && <Team />}
@@ -323,7 +345,7 @@ const Browse: React.FC<React.PropsWithChildren<any>> = ({viewer}) => {
       name: 'Next.js',
       href: '/q/next',
       image:
-        'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/074/square_64/nextjs.png',
+        'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/074/thumb/Group_1%281%29.png',
     },
     {
       name: 'Docker',
@@ -350,10 +372,10 @@ const Browse: React.FC<React.PropsWithChildren<any>> = ({viewer}) => {
         'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/230/square_64/aloglia_logo_1000x1000.png',
     },
     {
-      name: 'Python',
-      href: '/q/python',
+      name: 'Supabase',
+      href: '/q/supabase',
       image:
-        'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/138/square_64/2000px-Python-logo-notext.svg.png',
+        'https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/299/original/supabase-logo-icon_1.png',
     },
     {
       name: 'Go',

--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -196,11 +196,32 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
     )
   }
 
+  const Tips = () => {
+    return (
+      <Link href={`/tips`}>
+        <a
+          onClick={() =>
+            analytics.events.activityInternalLinkClick(
+              'tips',
+              'header',
+              'tips',
+              '/tips',
+            )
+          }
+          className="flex items-center h-full px-3 dark:hover:bg-white hover:bg-gray-50 dark:hover:bg-opacity-5"
+        >
+          Tips
+        </a>
+      </Link>
+    )
+  }
+
   const MobileNavigation = () => {
     return (
       <ul className="relative z-20 flex flex-col w-full px-3 pb-5 space-y-2 text-base dark:bg-gray-800 bg-gray-50 shadow-smooth">
         {[
           SearchBar,
+          !isEmpty(viewer) && Tips,
           !isEmpty(viewer) && Bookmarks,
           !isEmpty(viewer) && Feedback,
           showTeamNavLink && Team,
@@ -237,6 +258,7 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
               {!md && !isSearch && <SearchBar />}
               {!sm && (
                 <>
+                  {!isEmpty(viewer) && <Tips />}
                   {!isEmpty(viewer) && <Bookmarks />}
                   {!isEmpty(viewer) && <Feedback />}
                   {showTeamNavLink && <Team />}

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -66,6 +66,14 @@ export const getAllTips = async (onlyPublished = true): Promise<Tip[]> => {
         description,
         summary,
         body,
+        "tags": softwareLibraries[] {
+          ...(library->{
+            name,
+            'label': slug.current,
+            'http_url': url,
+            'image_url': image.url
+          })
+        },
         "videoResourceId": resources[@->._type == 'videoResource'][0]->_id,
         "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
         "slug": slug.current,
@@ -92,6 +100,14 @@ export const getTip = async (slug: string): Promise<Tip | null> => {
         description,
         summary,
         body,
+        "tags": softwareLibraries[] {
+          ...(library->{
+            name,
+            'label': slug.current,
+            'http_url': url,
+            'image_url': image.url
+          })
+        },
         "videoResourceId": resources[@->._type == 'videoResource'][0]->_id,
         "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
         "slug": slug.current,

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -14,6 +14,19 @@ export const TipSchema = z.object({
   description: z.nullable(z.string()).optional(),
   body: z.string().optional().nullable(),
   summary: z.string().optional().nullable(),
+  tags: z.nullable(
+    z
+      .array(
+        z.object({
+          name: z.string(),
+          label: z.string(),
+          image_url: z.string(),
+          http_url: z.string(),
+        }),
+      )
+      .optional(),
+  ),
+  duration: z.number().optional().nullable(),
   muxPlaybackId: z.nullable(z.string()).optional(),
   state: z.enum(['new', 'processing', 'reviewing', 'published', 'retired']),
   sandpack: z
@@ -30,6 +43,18 @@ export const TipSchema = z.object({
   transcript: z.nullable(z.string()).optional(),
   srt: z.nullable(z.string()).optional(),
   tweetId: z.nullable(z.string()).optional(),
+  instructor: z
+    .nullable(
+      z.object({
+        title: z.string(),
+        slug: z.string(),
+        name: z.string(),
+        path: z.string(),
+        twitter: z.string(),
+        image: z.string(),
+      }),
+    )
+    .optional(),
 })
 
 export const CoursesFromTagSchema = z.object({
@@ -66,19 +91,28 @@ export const getAllTips = async (onlyPublished = true): Promise<Tip[]> => {
         description,
         summary,
         body,
-        "tags": softwareLibraries[] {
-          ...(library->{
+        'tags': softwareLibraries[] {
+          ...(library-> {
             name,
             'label': slug.current,
             'http_url': url,
             'image_url': image.url
-          })
+          }),
         },
         "videoResourceId": resources[@->._type == 'videoResource'][0]->_id,
         "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+        "duration": resources[@->._type == 'videoResource'][0]->duration,
         "slug": slug.current,
         "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
-        "tweetId":  resources[@._type == 'tweet'][0].tweetId
+        "tweetId":  resources[@._type == 'tweet'][0].tweetId,
+        'instructor': collaborators[@->.role == 'instructor'][0]->{
+          title,
+          'slug': person->slug.current,
+          'name': person->name,
+          'path': person->website,
+          'twitter': person->twitter,
+          'image': person->image.url
+        },
   }`)
 
   return TipsSchema.parse(tips)
@@ -109,12 +143,21 @@ export const getTip = async (slug: string): Promise<Tip | null> => {
           })
         },
         "videoResourceId": resources[@->._type == 'videoResource'][0]->_id,
+        "duration": resources[@->._type == 'videoResource'][0]->duration,
         "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
         "slug": slug.current,
         "legacyTranscript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
         "transcript": resources[@->._type == 'videoResource'][0]-> transcript.text,
         "srt": resources[@->._type == 'videoResource'][0]-> transcript.srt,
-        "tweetId":  resources[@._type == 'tweet'][0].tweetId
+        "tweetId":  resources[@._type == 'tweet'][0].tweetId,
+        'instructor': collaborators[@->.role == 'instructor'][0]->{
+          title,
+          'slug': person->slug.current,
+          'name': person->name,
+          'path': person->website,
+          'twitter': person->twitter,
+          'image': person->image.url
+        },
     }`,
     {slug},
   )


### PR DESCRIPTION
The first step to making tips known is the nav and home page. 

Keeping this PR focused on home page, there's opportunities to add tips to individual instructor pages as well as topic pages.

![home page tips](https://github.com/skillrecordings/egghead-next/assets/6188161/7463c126-1149-44b5-a4d9-ffa2705bb8ea)


![g front and center](https://media2.giphy.com/media/4ClKwb8TJdfJcDKaQi/giphy.gif?cid=1927fc1bwz1l3muuauj3gt357hbfxtjs08kt1hl3tzwshhpg&ep=v1_gifs_search&rid=giphy.gif&ct=g)

