### PR TITLE
get 5 tips and sort by updatedAt

### DIFF
--- a/src/components/pages/home/sanity-sections.tsx
+++ b/src/components/pages/home/sanity-sections.tsx
@@ -168,7 +168,7 @@ const DynamicGridComponentWithTips = ({
   const publishedTips =
     data
       ?.find((tipGroup) => tipGroup.state === 'published')
-      ?.tips.slice(0, 4) ?? []
+      ?.tips.slice(0, 5) ?? []
 
   console.log({publishedTips})
 

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -82,7 +82,7 @@ export type Tip = z.infer<typeof TipSchema>
 export const getAllTips = async (onlyPublished = true): Promise<Tip[]> => {
   const tips = await sanityClient.fetch(groq`*[_type == "tip" ${
     onlyPublished ? `&& state == "published"` : ''
-  }] | order(_createdAt asc) {
+  }] | order(_updatedAt asc) {
         _id,
         _type,
         _updatedAt,


### PR DESCRIPTION
I wanted some more control over the order that tips show up on the home page, it makes sense that if we update a tip it gets bumped to the home page for people to view

![g update](https://media0.giphy.com/media/VdU7TZDHmWUTtFq2Mz/giphy.gif?cid=1927fc1bjvxybogyusuzm1eao5xwwgt2gg17x5wmc6vx8zl8&ep=v1_gifs_search&rid=giphy.gif&ct=g)