### PR TITLE
set user cookie to full user object in middleware

### DIFF
--- a/src/server/egghead-user-cookies.ts
+++ b/src/server/egghead-user-cookies.ts
@@ -5,23 +5,12 @@ export function setUserCookie(res: NextResponse, user: any) {
   if (user) {
     const {contact_id, email, first_name, last_name, is_pro, is_instructor} =
       user
-    res.cookies.set(
-      EGGHEAD_USER_COOKIE_KEY,
-      JSON.stringify({
-        contact_id,
-        email,
-        first_name,
-        last_name,
-        is_pro,
-        is_instructor,
-      }),
-      {
-        maxAge: 1000 * 60 * 60 * 24 * 2, // 2 days in milliseconds
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        domain: process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN,
-      },
-    )
+    res.cookies.set(EGGHEAD_USER_COOKIE_KEY, JSON.stringify(user), {
+      maxAge: 1000 * 60 * 60 * 24 * 2, // 2 days in milliseconds
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      domain: process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN,
+    })
   } else {
     clearUserCookie(res)
   }

--- a/src/server/egghead-user-cookies.ts
+++ b/src/server/egghead-user-cookies.ts
@@ -3,8 +3,6 @@ import {EGGHEAD_USER_COOKIE_KEY} from '../config'
 
 export function setUserCookie(res: NextResponse, user: any) {
   if (user) {
-    const {contact_id, email, first_name, last_name, is_pro, is_instructor} =
-      user
     res.cookies.set(EGGHEAD_USER_COOKIE_KEY, JSON.stringify(user), {
       maxAge: 1000 * 60 * 60 * 24 * 2, // 2 days in milliseconds
       secure: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
We are having an issue in #1384 where the user cookie has inconsistent values. 

In our middleware we are setting a minimal version of the `eh_user` cookie.

```
contact_id, email, first_name, last_name, is_pro, is_instructor
```

 In the `refreshUser` function within the `Auth` class we are setting the `eh_user` cookie to be the full user object that we get back from the `/api/users/current` route.
 
 While this cookie is huge, there are attributes in it that we expect to be there (namely the user id) that isn't upon initial render because the cookie is being set with just these handful of attributes seen above.
 
 This PR sets the full user object we get from `/api/users/current` instead of the striped down version.
 
 ![cookie](https://media4.giphy.com/media/3ohhwgL82StH82ufyo/giphy.gif?cid=1927fc1bn9ybjqzubcmoeysbnejsvkf250g0cm0mxmir43o3&ep=v1_gifs_search&rid=giphy.gif&ct=g)