### PR TITLE
feat: disable automatic session recording

### DIFF
--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -12,6 +12,7 @@ class PosthogClient {
         },
         capture_pageview: false, // Disable automatic pageview capture, as we capture manually
         autocapture: false, // Disable automatic default event capture, as we capture manually
+        disable_session_recording: true, // This disables session capture by default. We can still choose to capture sessions manually. See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record
       })
     }
 


### PR DESCRIPTION
Sessions were being recorded by default without my knowledge.

This changes the config so that sessions aren't being automatically recorded. We can manually start and stop session recordings if we choose in the future. 

See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record