### PR TITLE
Track written tip reads and tip page views

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "next-transpile-modules": "^8.0.0",
     "nextjs-sitemap-generator": "^1.3.1",
     "pluralize": "^8.0.0",
-    "posthog-js": "^1.85.2",
+    "posthog-js": "^1.88.1",
     "prism-react-renderer": "^1.2.1",
     "prisma": "4.7.0",
     "qs": "^6.10.5",

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,11 +4,11 @@ import {ViewerProvider} from 'context/viewer-context'
 import {CioProvider} from 'hooks/use-cio'
 import {ThemeProvider} from 'next-themes'
 import TrpcProvider from 'app/_trpc/Provider'
-import PosthogClient from 'lib/posthog-client'
+import PostHogClient from 'lib/posthog-client'
 import {PostHogProvider} from 'posthog-js/react'
 
 export function Providers({children}: {children: React.ReactNode}) {
-  const posthog = PosthogClient.init()
+  const posthog = PostHogClient
 
   return (
     <ThemeProvider attribute="class">

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,13 +4,19 @@ import {ViewerProvider} from 'context/viewer-context'
 import {CioProvider} from 'hooks/use-cio'
 import {ThemeProvider} from 'next-themes'
 import TrpcProvider from 'app/_trpc/Provider'
+import PosthogClient from 'lib/posthog-client'
+import {PostHogProvider} from 'posthog-js/react'
 
 export function Providers({children}: {children: React.ReactNode}) {
+  const posthog = PosthogClient.init()
+
   return (
     <ThemeProvider attribute="class">
       <ViewerProvider>
         <TrpcProvider>
-          <CioProvider>{children}</CioProvider>
+          <CioProvider>
+            <PostHogProvider client={posthog}>{children}</PostHogProvider>
+          </CioProvider>
         </TrpcProvider>
       </ViewerProvider>
     </ThemeProvider>

--- a/src/components/tips/tip-template.tsx
+++ b/src/components/tips/tip-template.tsx
@@ -31,7 +31,6 @@ const TipTemplate = ({
   tips: Tip[]
   coursesFromTag: any
 }) => {
-  // I'm calling the usePostHog hook and building the event capture here since our track method is not working in the client side app router.
   const markComplete = {mutateAsync: ({tipId}: {tipId: any}) => true} //trpc.tips.markTipComplete.useMutation()
 
   const {instructor, tags} = tip

--- a/src/components/tips/tip-template.tsx
+++ b/src/components/tips/tip-template.tsx
@@ -20,7 +20,7 @@ import {trpc} from 'app/_trpc/client'
 import {twMerge} from 'tailwind-merge'
 import analytics from 'utils/analytics'
 import {useScrollTracker} from 'react-scroll-tracker'
-import {usePostHog} from 'posthog-js/react'
+import PostHogClient from 'lib/posthog-client'
 
 const TipTemplate = ({
   tip,
@@ -32,7 +32,6 @@ const TipTemplate = ({
   coursesFromTag: any
 }) => {
   // I'm calling the usePostHog hook and building the event capture here since our track method is not working in the client side app router.
-  const posthog = usePostHog()
   const markComplete = {mutateAsync: ({tipId}: {tipId: any}) => true} //trpc.tips.markTipComplete.useMutation()
 
   const {instructor, tags} = tip
@@ -48,10 +47,14 @@ const TipTemplate = ({
   const {scrollY} = useScrollTracker([50])
 
   React.useEffect(() => {
+    PostHogClient?.capture('tip_page_viewed', {slug: tip.slug})
+  }, [tip.slug])
+
+  React.useEffect(() => {
     if (scrollY >= 50) {
-      posthog?.capture('written_tip_read', {slug: tip.slug})
+      PostHogClient?.capture('written_tip_read', {slug: tip.slug})
     }
-  }, [scrollY, posthog, tip.slug])
+  }, [scrollY, tip.slug])
 
   const module: any = {
     slug: {

--- a/src/components/tips/tip-template.tsx
+++ b/src/components/tips/tip-template.tsx
@@ -19,6 +19,8 @@ import Tags from 'components/pages/lessons/tags'
 import {trpc} from 'app/_trpc/client'
 import {twMerge} from 'tailwind-merge'
 import analytics from 'utils/analytics'
+import {useScrollTracker} from 'react-scroll-tracker'
+import {usePostHog} from 'posthog-js/react'
 
 const TipTemplate = ({
   tip,
@@ -29,6 +31,8 @@ const TipTemplate = ({
   tips: Tip[]
   coursesFromTag: any
 }) => {
+  // I'm calling the usePostHog hook and building the event capture here since our track method is not working in the client side app router.
+  const posthog = usePostHog()
   const markComplete = {mutateAsync: ({tipId}: {tipId: any}) => true} //trpc.tips.markTipComplete.useMutation()
 
   const {instructor, tags} = tip
@@ -40,6 +44,14 @@ const TipTemplate = ({
     }
     console.log('video ended')
   }
+
+  const {scrollY} = useScrollTracker([50])
+
+  React.useEffect(() => {
+    if (scrollY >= 50) {
+      posthog?.capture('written_tip_read', {slug: tip.slug})
+    }
+  }, [scrollY, posthog, tip.slug])
 
   const module: any = {
     slug: {

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -1,27 +1,23 @@
 import posthog from 'posthog-js'
 
-class PosthogClient {
-  static init() {
-    if (typeof window !== 'undefined') {
-      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
-        api_host:
-          process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
-        // Enable debug mode in development
-        loaded: (posthog) => {
-          if (process.env.NODE_ENV === 'development') posthog.debug()
-        },
-        capture_pageview: false, // Disable automatic pageview capture, as we capture manually
-        autocapture: false, // Disable automatic default event capture, as we capture manually
-        disable_session_recording: true, // This disables session capture by default. We can still choose to capture sessions manually. See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record
-      })
-    }
-
-    return posthog
+export const SetupPostHogClient = () => {
+  if (typeof window !== 'undefined') {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
+      api_host:
+        process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+      // Enable debug mode in development
+      loaded: (posthog) => {
+        if (process.env.NODE_ENV === 'development') posthog.debug()
+      },
+      capture_pageview: false, // Disable automatic pageview capture, as we capture manually
+      autocapture: false, // Disable automatic default event capture, as we capture manually
+      disable_session_recording: true, // This disables session capture by default. We can still choose to capture sessions manually. See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record
+    })
   }
 
-  static capture(event: string, params: any) {
-    posthog.capture(event, params)
-  }
+  return posthog
 }
 
-export default PosthogClient
+const PostHogClient = SetupPostHogClient()
+
+export default PostHogClient

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,7 +23,7 @@ import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 import TrpcProvider from 'app/_trpc/Provider'
 
 import {PostHogProvider} from 'posthog-js/react'
-import PosthogClient from 'lib/posthog-client'
+import PostHogClient from 'lib/posthog-client'
 
 declare global {
   interface Window {
@@ -41,7 +41,7 @@ export function reportWebVitals(metric: NextWebVitalsMetric) {
   console.debug(`web vitals`, metric)
 }
 
-const posthog = PosthogClient.init()
+const posthog = PostHogClient
 
 const App: React.FC<React.PropsWithChildren<AppProps>> = ({
   Component,

--- a/src/utils/analytics/track.ts
+++ b/src/utils/analytics/track.ts
@@ -3,10 +3,11 @@ import {Viewer} from 'types'
 import Auth from '../auth'
 import mixpanel from 'mixpanel-browser'
 import {identify} from './identify'
-import PosthogClient from 'lib/posthog-client'
+import PostHogClient from 'lib/posthog-client'
 const DEBUG_ANALYTICS = true
 
 mixpanel.init(process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || '')
+const posthog = PostHogClient
 
 export const track = (
   event: string,
@@ -62,7 +63,7 @@ export const track = (
       }
 
       mixpanel.track(event, params)
-      PosthogClient.capture(event, params)
+      posthog.capture(event, params)
 
       if (
         viewer &&

--- a/src/utils/analytics/track.ts
+++ b/src/utils/analytics/track.ts
@@ -2,7 +2,6 @@ import {isFunction, isUndefined} from 'lodash'
 import {Viewer} from 'types'
 import Auth from '../auth'
 import mixpanel from 'mixpanel-browser'
-import posthog from 'posthog-js'
 import {identify} from './identify'
 import PosthogClient from 'lib/posthog-client'
 const DEBUG_ANALYTICS = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -18237,10 +18237,10 @@ postcss@^8.2.15, postcss@^8.4.23, postcss@^8.4.27, postcss@^8.4.5:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.85.2:
-  version "1.85.2"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.85.2.tgz#d540a17baac2d67d631a4c83fb498b698f135fc4"
-  integrity sha512-xKteAKQhhNhOPWHUEso7Ajm7Qk+lJnDH4JVJ+r4kti62sXtVTSmayhDZoPgiCmQ3w1YtvL13wojb1IbpCpxScw==
+posthog-js@^1.88.1:
+  version "1.88.1"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.88.1.tgz#ab81f21ec158a9c57be0e696744a9c9f6967ba3b"
+  integrity sha512-+8kFFU5KIcFSm8zB3tX8l0GSPyq/OtMtdrS9dYpMJk6nsEwXvOjkwFEpSrYzL5eGEpTPdbM65M52HvMqqsjpXw==
   dependencies:
     fflate "^0.4.1"
 


### PR DESCRIPTION
This uses PostHog to track if people are scrolling down and viewing the written lessons. I'm also tracking page views to compare with the number of reads. 

I've also switched from using a class with static methods to a function that initializes the Posthog client. And, added a posthog provider to the app routes

![](https://media.giphy.com/media/3orieTdW0Vhir8L1ug/giphy.gif)