### PR TITLE
add metadata to tip pages

### DIFF
--- a/src/app/tips/[tipId]/page.tsx
+++ b/src/app/tips/[tipId]/page.tsx
@@ -30,14 +30,14 @@ export async function generateMetadata(
     }),
     openGraph: {
       images: [
-        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png',
+        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1699475351/og-images/card-tips-index_2x.png',
         ...previousImages,
       ],
     },
     twitter: {
       title: truncate(tip.title, {length: 65}),
       images: [
-        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png',
+        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1699475351/og-images/card-tips-index_2x.png',
         ...previousImages,
       ],
       site: 'eggheadio',

--- a/src/app/tips/[tipId]/page.tsx
+++ b/src/app/tips/[tipId]/page.tsx
@@ -45,44 +45,31 @@ export async function generateMetadata(
   }
 }
 
-{
-  /* <NextSeo
-  title={truncate(tip.title, {length: 65})}
-  description={truncate(removeMarkdown(tip.description), {
-    length: 155,
-  })}
-  openGraph={{
-    title: truncate(tip.title, {length: 65}),
-    description: truncate(removeMarkdown(tip.description), {
-      length: 155,
-    }),
-    site_name: 'egghead',
-    images: [
-      {
-        url: "https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png",
-      },
-    ],
-  }}
-  twitter={{
-    cardType: 'summary_large_image',
-    site: 'eggheadio',
-  }}
-/> */
-}
-
 export default async function Tip({params}: {params: {tipId: string}}) {
   const tip = await serverClient.tips.bySlug({slug: params.tipId})
   const allTips = await serverClient.tips.all()
   const coursesFromTag = await serverClient.tips.relatedContent({
     slug: params.tipId,
   })
-
   const publishedTips =
     allTips.find((tipGroup) => tipGroup.state === 'published')?.tips ?? []
+  const muxPlaybackId = tip?.muxPlaybackId
+  const thumbnail = `https://image.mux.com/${muxPlaybackId}/thumbnail.png?width=720&height=405&fit_mode=preserve`
+
+  const jsonLd = {
+    name: tip.title,
+    image: thumbnail,
+    uploadDate: tip?._createdAt,
+    description: removeMarkdown(tip.description),
+  }
 
   return (
     tip && (
       <>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{__html: JSON.stringify(jsonLd)}}
+        />
         <TipTemplate
           tip={tip}
           tips={publishedTips}

--- a/src/app/tips/[tipId]/page.tsx
+++ b/src/app/tips/[tipId]/page.tsx
@@ -1,5 +1,74 @@
 import TipTemplate from 'components/tips/tip-template'
 import {serverClient} from 'app/_trpc/serverClient'
+import truncate from 'lodash/truncate'
+import removeMarkdown from 'remove-markdown'
+
+import type {Metadata, ResolvingMetadata} from 'next'
+
+type Props = {
+  params: {tipId: string}
+  searchParams: {[key: string]: string | string[] | undefined}
+}
+
+export async function generateMetadata(
+  {params, searchParams}: Props,
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  // read route params
+  const tipId = params?.tipId
+
+  // fetch data
+  const tip = await serverClient.tips.bySlug({slug: params.tipId})
+
+  // optionally access and extend (rather than replace) parent metadata
+  const previousImages = (await parent).openGraph?.images || []
+
+  return {
+    title: truncate(tip.title, {length: 65}),
+    description: truncate(removeMarkdown(tip.description), {
+      length: 155,
+    }),
+    openGraph: {
+      images: [
+        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png',
+        ...previousImages,
+      ],
+    },
+    twitter: {
+      title: truncate(tip.title, {length: 65}),
+      images: [
+        'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png',
+        ...previousImages,
+      ],
+      site: 'eggheadio',
+    },
+  }
+}
+
+{
+  /* <NextSeo
+  title={truncate(tip.title, {length: 65})}
+  description={truncate(removeMarkdown(tip.description), {
+    length: 155,
+  })}
+  openGraph={{
+    title: truncate(tip.title, {length: 65}),
+    description: truncate(removeMarkdown(tip.description), {
+      length: 155,
+    }),
+    site_name: 'egghead',
+    images: [
+      {
+        url: "https://res.cloudinary.com/dg3gyk0gu/image/upload/v1632239045/og-image-assets/egghead-og-image.png",
+      },
+    ],
+  }}
+  twitter={{
+    cardType: 'summary_large_image',
+    site: 'eggheadio',
+  }}
+/> */
+}
 
 export default async function Tip({params}: {params: {tipId: string}}) {
   const tip = await serverClient.tips.bySlug({slug: params.tipId})


### PR DESCRIPTION
We don't have metadata set for tips pages so this does that


![mouse](https://media3.giphy.com/media/XfBtsIAbXUJIk/giphy.gif?cid=1927fc1b6bq2xp2o5el6ecc2cd45z5y0k56ts4h85k66fla6&ep=v1_gifs_search&rid=giphy.gif&ct=g)