### PR TITLE
feat: add cache revalidation to getTip and sanityQuery

### DIFF
--- a/src/app/tips/[tipId]/edit/page.tsx
+++ b/src/app/tips/[tipId]/edit/page.tsx
@@ -8,10 +8,7 @@ import {Suspense} from 'react'
 import {notFound} from 'next/navigation'
 
 const EditTip = async ({params}: {params: {tipId: string}}) => {
-  console.log(params)
   const tip = await getTip(params.tipId as string)
-
-  console.log()
 
   if (!tip) {
     return notFound()

--- a/src/components/EggheadPlayer/players/Bitmovin.js
+++ b/src/components/EggheadPlayer/players/Bitmovin.js
@@ -346,7 +346,7 @@ export default class Bitmovin extends Base {
       },
       (error) => {
         console.log('Bitmovin player failed to load')
-        console.log(error)
+        console.error(error)
       },
     )
   }

--- a/src/components/pages/home/sanity-sections.tsx
+++ b/src/components/pages/home/sanity-sections.tsx
@@ -168,8 +168,6 @@ const DynamicGridComponentWithTips = ({
 
   const publishedTips = data || []
 
-  console.log({publishedTips})
-
   const rowOneResources = section?.resources?.slice(0, 2)
   const rowTwoResources = section?.resources?.slice(2, 8)
 

--- a/src/components/pages/lessons/overlay/anon-user-overlay.tsx
+++ b/src/components/pages/lessons/overlay/anon-user-overlay.tsx
@@ -208,7 +208,6 @@ const AnonUserOverlay: React.FunctionComponent<
   const courseImage = lesson?.collection?.square_cover_480_url
   const router = useRouter()
   const tag = lesson.tags[0]
-  console.log(lesson)
   const hits = transformHits(
     trpc.topics.top.useQuery({topic: tag.name})?.data,
     2,

--- a/src/hooks/mux/use-mux-player.tsx
+++ b/src/hooks/mux/use-mux-player.tsx
@@ -182,8 +182,6 @@ export const VideoProvider: React.FC<
   const isModuleComplete =
     nextExerciseStatus !== 'loading' && !nextExercise && !nextSection
 
-  console.log(module, lesson)
-
   const isFirstLessonInModule =
     (module.lessons &&
       Boolean(module.lessons?.length) &&

--- a/src/hooks/use-convertkit-form.ts
+++ b/src/hooks/use-convertkit-form.ts
@@ -8,8 +8,8 @@ import {type Subscriber} from '../schemas/subscriber'
 // } from '@skillrecordings/config'
 
 export function useConvertkitForm({
-  submitUrl = process.env.NEXT_PUBLIC_CONVERTKIT_SUBSCRIBE_URL ,
-  formId = (0) as number,
+  submitUrl = process.env.NEXT_PUBLIC_CONVERTKIT_SUBSCRIBE_URL,
+  formId = 0 as number,
   fields,
   onSuccess,
   onError,
@@ -51,7 +51,7 @@ export function useConvertkitForm({
         .catch((error: Error) => {
           onError(error)
           setStatus('error')
-          console.log(error)
+          console.error(error)
         })
     },
   })

--- a/src/inngest/functions/mux/mux-webhooks-handlers.ts
+++ b/src/inngest/functions/mux/mux-webhooks-handlers.ts
@@ -40,6 +40,7 @@ export const muxVideoAssetReady = inngest.createFunction(
       const resourceTemp = VideoResourceSchema.safeParse(
         await sanityQuery(
           `*[_type == "videoResource" && muxAssetId == "${event.data.muxWebhookEvent.data.id}"][0]`,
+          false,
         ),
       )
       return resourceTemp.success ? resourceTemp.data : null

--- a/src/inngest/functions/video-uploaded.ts
+++ b/src/inngest/functions/video-uploaded.ts
@@ -16,6 +16,7 @@ export const videoUploaded = inngest.createFunction(
       sanityModule = await step.run('get the module from Sanity', async () => {
         return await sanityQuery(
           `*[_type == "module" && slug.current == "${event.data.moduleSlug}"][0]`,
+          false,
         )
       })
     }
@@ -50,6 +51,7 @@ export const videoUploaded = inngest.createFunction(
 
         return await sanityQuery(
           `*[_type == "videoResource" && _id == "${event.data.fileName}"][0]`,
+          false,
         )
       },
     )

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -136,11 +136,7 @@ export const getAllTips = async (
     },
   }${sliceClause}`
 
-  console.log(query)
-
   const tips = await sanityQuery<Tip[]>(query)
-
-  console.log({tips})
 
   return tips
 }

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -185,7 +185,7 @@ export const getTip = async (slug: string): Promise<Tip | null> => {
     }`,
     {slug},
     {
-      cache: 'no-cache',
+      next: {revalidate: 3600},
     },
   )
 

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -184,6 +184,9 @@ export const getTip = async (slug: string): Promise<Tip | null> => {
         },
     }`,
     {slug},
+    {
+      cache: 'no-cache',
+    },
   )
 
   if (tip?.legacyTranscript && !tip.transcript) {

--- a/src/lib/tips.ts
+++ b/src/lib/tips.ts
@@ -136,7 +136,11 @@ export const getAllTips = async (
     },
   }${sliceClause}`
 
+  console.log(query)
+
   const tips = await sanityQuery<Tip[]>(query)
+
+  console.log({tips})
 
   return tips
 }

--- a/src/module-builder/edit-tip-form.tsx
+++ b/src/module-builder/edit-tip-form.tsx
@@ -44,7 +44,7 @@ const EditTipForm: React.FC<{tip: Tip}> = ({tip}) => {
         },
       )
     } catch (error) {
-      console.log(error)
+      console.error(error)
     }
   }
 

--- a/src/pages/blank.tsx
+++ b/src/pages/blank.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react'
-import Redirect from './redirect'
 import {trpc} from '@/app/_trpc/client'
 
 const Blank = () => {
   const {data} = trpc.topics.top.useQuery({topic: 'react'})
-  console.log(data)
   return <div>this page is intentionally blank</div>
 }
 

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -117,8 +117,6 @@ const UploadWrapper = ({
         })
 
         setSubmitResponse(response)
-
-        console.log({response})
       }}
     >
       {(props) => (

--- a/src/utils/sanity-server.ts
+++ b/src/utils/sanity-server.ts
@@ -9,11 +9,14 @@ export const sanityWriteClient = createClient({
   token: process.env.SANITY_EDITOR_TOKEN,
 })
 
-export async function sanityQuery<T = any>(query: string): Promise<T> {
+export async function sanityQuery<T = any>(
+  query: string,
+  useCdn: boolean = true,
+): Promise<T> {
   return await fetch(
-    `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v${
-      process.env.NEXT_PUBLIC_SANITY_API_VERSION
-    }/data/query/${
+    `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.${
+      useCdn ? 'apicdn' : 'api'
+    }.sanity.io/v${process.env.NEXT_PUBLIC_SANITY_API_VERSION}/data/query/${
       process.env.NEXT_PUBLIC_SANITY_DATASET
     }?query=${encodeURIComponent(query)}`,
     {

--- a/src/utils/sanity-server.ts
+++ b/src/utils/sanity-server.ts
@@ -1,4 +1,5 @@
 import {createClient} from '@sanity/client'
+import {pickBy} from 'lodash'
 
 export const sanityWriteClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
@@ -13,7 +14,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
     `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v${
       process.env.NEXT_PUBLIC_SANITY_API_VERSION
     }/data/query/${
-      process.env.NEXT_PUBLIC_SANITY_DATASET_ID
+      process.env.NEXT_PUBLIC_SANITY_DATASET
     }?query=${encodeURIComponent(query)}`,
     {
       method: 'get',
@@ -24,6 +25,13 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
     },
   )
     .then(async (response) => {
+      if (response.status !== 200) {
+        throw new Error(
+          `Sanity Query failed with status ${response.status}: ${
+            response.statusText
+          }\n\n\n${JSON.stringify(await response.json(), null, 2)})}`,
+        )
+      }
       const {result} = await response.json()
       return result as T
     })
@@ -35,7 +43,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
 
 export async function sanityMutation(mutations: any[]) {
   return await fetch(
-    `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v${process.env.NEXT_PUBLIC_SANITY_API_VERSION}/data/mutate/${process.env.NEXT_PUBLIC_SANITY_DATASET_ID}`,
+    `https://${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}.api.sanity.io/v${process.env.NEXT_PUBLIC_SANITY_API_VERSION}/data/mutate/${process.env.NEXT_PUBLIC_SANITY_DATASET}`,
     {
       method: 'post',
       headers: {

--- a/src/utils/sanity-server.ts
+++ b/src/utils/sanity-server.ts
@@ -20,6 +20,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
       headers: {
         Authorization: `Bearer ${process.env.SANITY_EDITOR_TOKEN}`,
       },
+      next: {revalidate: 3600},
     },
   )
     .then(async (response) => {

--- a/src/utils/sanity-server.ts
+++ b/src/utils/sanity-server.ts
@@ -36,7 +36,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
       return result as T
     })
     .catch((error) => {
-      console.log(error)
+      console.error(error)
       throw error
     })
 }

--- a/src/utils/sanity-server.ts
+++ b/src/utils/sanity-server.ts
@@ -21,7 +21,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
       headers: {
         Authorization: `Bearer ${process.env.SANITY_EDITOR_TOKEN}`,
       },
-      next: {revalidate: 3600},
+      next: {revalidate: 10},
     },
   )
     .then(async (response) => {

--- a/src/utils/sanity.fetch.only.server.ts
+++ b/src/utils/sanity.fetch.only.server.ts
@@ -12,11 +12,14 @@ export async function sanityMutation(mutations: any[]) {
   ).then((response) => response.json())
 }
 
-export async function sanityQuery<T = any>(query: string): Promise<T> {
+export async function sanityQuery<T = any>(
+  query: string,
+  useCdn: boolean = true,
+): Promise<T> {
   return await fetch(
-    `https://${process.env.SANITY_STUDIO_PROJECT_ID}.api.sanity.io/v${
-      process.env.SANITY_STUDIO_API_VERSION
-    }/data/query/${
+    `https://${process.env.SANITY_STUDIO_PROJECT_ID}.${
+      useCdn ? 'apicdn' : 'api'
+    }.sanity.io/v${process.env.SANITY_STUDIO_API_VERSION}/data/query/${
       process.env.SANITY_STUDIO_DATASET
     }?query=${encodeURIComponent(query)}`,
     {

--- a/src/utils/sanity.fetch.only.server.ts
+++ b/src/utils/sanity.fetch.only.server.ts
@@ -24,7 +24,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
       headers: {
         Authorization: `Bearer ${process.env.SANITY_API_TOKEN}`,
       },
-      next: {revalidate: 3600},
+      next: {revalidate: 10},
     },
   )
     .then(async (response) => {

--- a/src/utils/sanity.fetch.only.server.ts
+++ b/src/utils/sanity.fetch.only.server.ts
@@ -32,7 +32,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
       return result as T
     })
     .catch((error) => {
-      console.log(error)
+      console.error(error)
       throw error
     })
 }

--- a/src/utils/sanity.fetch.only.server.ts
+++ b/src/utils/sanity.fetch.only.server.ts
@@ -7,6 +7,7 @@ export async function sanityMutation(mutations: any[]) {
         'Content-type': 'application/json',
         Authorization: `Bearer ${process.env.SANITY_API_TOKEN}`,
       },
+      next: {revalidate: 3600},
       body: JSON.stringify({mutations}),
     },
   ).then((response) => response.json())
@@ -24,6 +25,7 @@ export async function sanityQuery<T = any>(query: string): Promise<T> {
       headers: {
         Authorization: `Bearer ${process.env.SANITY_API_TOKEN}`,
       },
+      next: {revalidate: 3600},
     },
   )
     .then(async (response) => {

--- a/src/utils/sanity.fetch.only.server.ts
+++ b/src/utils/sanity.fetch.only.server.ts
@@ -7,7 +7,6 @@ export async function sanityMutation(mutations: any[]) {
         'Content-type': 'application/json',
         Authorization: `Bearer ${process.env.SANITY_API_TOKEN}`,
       },
-      next: {revalidate: 3600},
       body: JSON.stringify({mutations}),
     },
   ).then((response) => response.json())


### PR DESCRIPTION
I browsed the Sanity slack for caching issues and several people were having problems with Sanity and the app router. 

There were a couple of solutions: route based configuration, and params on individual fetch requests. I've gone ahead and added a `cache: 'no-cache`' param to the request in `getTip`. It seems to be working locally.

I wanted to do this instead of flipping `useCdn` which would affect everything.

https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#individual-fetch-requests

# Update 1

Instead of disabling cache on fetch, @joelhooks suggested that we instead set the request to be revalidated. I've gone ahead and added this to the `sanityQuery` as well

# Update 2 (2023-12-14)

For `getTip` and `getAllTips`, I've switched to using global fetch in @joelhooks's `sanityQuery` function. I added the `next: { revalidate: 3600 }` configuration to the fetch in `sanityQuery`

![](https://media.giphy.com/media/XBEoaajXTXaALzawSn/giphy.gif)