### PR TITLE
Allows crawlers to load lesson page content

### DIFF
--- a/src/pages/invoices/index.tsx
+++ b/src/pages/invoices/index.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react'
 import LoginRequired from '@/components/login-required'
 import Invoices from '@/components/invoices'
+import {NextSeo} from 'next-seo'
 
 const InvoicesPage: React.FunctionComponent<
   React.PropsWithChildren<any>
 > = () => {
   return (
-    <LoginRequired>
-      <Invoices headingAs="h1" />
-    </LoginRequired>
+    <>
+      <NextSeo noindex={true} />
+      <LoginRequired>
+        <Invoices headingAs="h1" />
+      </LoginRequired>
+    </>
   )
 }
 


### PR DESCRIPTION
Lesson pages were not being previewed due to Webpack chunks being blocked in the robots.txt.

I've adjusted the robots.txt generation so that only unneccesary files are disallowed.

# Before 

<img width="954" alt="image" src="https://github.com/skillrecordings/egghead-next/assets/518406/22ed83f6-2f7a-4a4f-81fc-e2b3066c1ab8">

<img width="409" alt="image" src="https://github.com/skillrecordings/egghead-next/assets/518406/b8a699dd-d960-44e7-88fa-2a9c29b5fa67">


# After

<img width="912" alt="image" src="https://github.com/skillrecordings/egghead-next/assets/518406/eb6a7130-05ba-42c4-8c6c-66764594c5b0">
<img width="396" alt="image" src="https://github.com/skillrecordings/egghead-next/assets/518406/fa6369ae-c94c-4f14-819f-1822ebb63c81">
