### PR TITLE
Course page redirects if course not found in sanity

### DIFF
--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -124,7 +124,7 @@ export async function loadCourseMetadata(id: number, slug: string) {
 
   const course = await sanityClient.fetch(courseQuery, params)
 
-  if (!course?.square_cover_480_url) {
+  if (course && !course?.square_cover_480_url) {
     const imageUrl = course?.dependencies
       ? `https://res.cloudinary.com/dg3gyk0gu/image/upload/v1683914713/tags/${course?.dependencies[0]?.name}.png`
       : 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1569292667/eggo/eggo_flair.png'


### PR DESCRIPTION
When trying to load sanity data, we check if the course has a course image but assume the course is in sanity and add a default if not. 

When a course happens to not be represented in sanity this forces a redirect because we are trying to modify a null object.

Adding a check for the course object allows the course to still load

![whoops](https://media0.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif?cid=1927fc1botb9ipi20e7rqbwz664x68srl1f10jyi3abs4c8j&ep=v1_gifs_search&rid=giphy.gif&ct=g)