### PR TITLE
add structured metadata to pages

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -7,7 +7,7 @@ import InstructorProfile from '@/components/pages/courses/instructor-profile'
 import PlayIcon from '@/components/pages/courses/play-icon'
 import getDependencies from '@/data/courseDependencies'
 import {get, first, filter, isEmpty, take, truncate} from 'lodash'
-import {NextSeo} from 'next-seo'
+import {NextSeo, SocialProfileJsonLd, CourseJsonLd} from 'next-seo'
 import removeMarkdown from 'remove-markdown'
 import {track} from '@/utils/analytics'
 import analytics from '@/utils/analytics'
@@ -423,6 +423,18 @@ const CollectionPageLayout: React.FunctionComponent<
             },
           ],
         }}
+      />
+      <SocialProfileJsonLd
+        type="Person"
+        name={name}
+        url={`https://egghead.io/q/resources-by-${slug}`}
+        sameAs={[twitter, instructor.website]}
+      />
+      <CourseJsonLd
+        courseName={title}
+        providerName="egghead.io"
+        providerUrl="https://egghead.io"
+        description={truncate(removeMarkdown(description), {length: 155})}
       />
       <div className="container pb-8 sm:pb-16 dark:text-gray-100">
         {state === 'retired' && (

--- a/src/components/pages/lessons/lesson/index.tsx
+++ b/src/components/pages/lessons/lesson/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {useRouter} from 'next/router'
-import {filter, get, isEmpty, compact} from 'lodash'
+import {filter, get, isEmpty, compact, truncate} from 'lodash'
 import {Tab, TabList, TabPanel, TabPanels, Tabs} from '@reach/tabs'
 import {useEggheadPlayer} from '@/components/EggheadPlayer'
 import Course from '@/components/pages/lessons/course'
@@ -8,7 +8,7 @@ import Overlays from '@/components/pages/lessons/overlays'
 import specialLessons from '@/components/pages/lessons/special-lessons'
 import Transcript from '@/components/pages/lessons/transcript'
 import {VideoResource} from '@/types'
-import {NextSeo, VideoJsonLd} from 'next-seo'
+import {NextSeo, SocialProfileJsonLd, VideoJsonLd} from 'next-seo'
 import removeMarkdown from 'remove-markdown'
 import {useEnhancedTranscript} from '@/hooks/use-enhanced-transcript'
 import useLastResource from '@/hooks/use-last-resource'
@@ -488,7 +488,7 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
   return (
     <>
       <NextSeo
-        description={removeMarkdown(description)}
+        description={truncate(removeMarkdown(description), {length: 155})}
         canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${lesson.path}`}
         title={title}
         titleTemplate={'%s | egghead.io'}
@@ -500,7 +500,7 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
         openGraph={{
           title,
           url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${lesson.path}`,
-          description: removeMarkdown(description),
+          description: truncate(removeMarkdown(description), {length: 155}),
           site_name: 'egghead',
           images: [
             {
@@ -511,9 +511,15 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
       />
       <VideoJsonLd
         name={title}
-        description={removeMarkdown(description)}
+        description={truncate(removeMarkdown(description), {length: 155})}
         uploadDate={lesson?.created_at}
         thumbnailUrls={compact([lesson?.thumb_url])}
+      />
+      <SocialProfileJsonLd
+        type="Person"
+        name={instructor.full_name}
+        url={`https://egghead.io/${instructorPagePath}`}
+        sameAs={[`https://twitter.com/${instructor.twitter}`]}
       />
       <div className={cx({'h-screen': isFullscreen})}>
         <div

--- a/src/components/search/instructors/instructor-essential.tsx
+++ b/src/components/search/instructors/instructor-essential.tsx
@@ -1,7 +1,7 @@
 import React, {FunctionComponent} from 'react'
 import Markdown from 'react-markdown'
 import Image from 'next/legacy/image'
-import {NextSeo} from 'next-seo'
+import {NextSeo, SocialProfileJsonLd} from 'next-seo'
 import DefaultCTA from '../curated/default-cta'
 import analytics from '@/utils/analytics'
 import {useRouter} from 'next/router'
@@ -49,6 +49,12 @@ const SearchInstructorEssential: FunctionComponent<
             },
           ],
         }}
+      />
+      <SocialProfileJsonLd
+        type="Person"
+        name={name}
+        url={`https://egghead.io/q/resources-by-${slug}`}
+        sameAs={[twitterHandle, instructor.website]}
       />
       <div className="items-center flex flex-col grid-cols-1 space-y-12 lg:grid lg:grid-cols-12 lg:space-y-0 dark:bg-gray-900">
         <div

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -27,6 +27,8 @@ const courseQuery = groq`
     "avatar_url": person->image.url,
     "full_name": person->name,
     "slug": person->slug.current,
+    "website": person->website,
+    "twitter": person->twitter,
     "id": _id
   },
   "tags": softwareLibraries[] {
@@ -50,7 +52,9 @@ const courseQuery = groq`
   'instructor': collaborators[@->.role == "instructor"][0]->{
     'full_name': person->name,
     'avatar_url': person->image.url,
-    'slug': person->slug.current
+    'slug': person->slug.current,
+    "website": person->website,
+    "twitter": person->twitter,
   },
   'dependencies': softwareLibraries[]{
     version,
@@ -158,6 +162,8 @@ export async function loadDraftSanityCourse(slug: string, token?: string) {
       "avatar_url": person->image.url,
       "full_name": person->name,
       "slug": person->slug.current,
+      "website": person->website,
+      "twitter": person->twitter,
       "id": _id
     },
     "tags": softwareLibraries[] {
@@ -190,6 +196,8 @@ export async function loadSanityInstructorbyCourseId(
       "avatar_url": person->image.url,
       "full_name": person->name,
       "slug": person->slug.current,
+      "website": person->website,
+      "twitter": person->twitter,
       "id": _id
     },
  }`
@@ -220,6 +228,8 @@ export async function loadDraftSanityCourseById(id: string, token?: string) {
       "avatar_url": person->image.url,
       "full_name": person->name,
       "slug": person->slug.current,
+      "website": person->website,
+      "twitter": person->twitter,
       "id": _id
     },
     "tags": softwareLibraries[] {
@@ -261,6 +271,8 @@ const SanityInstructorSchema = z.object({
   full_name: z.string(),
   slug: z.string(),
   id: z.string(),
+  website: z.string(),
+  twitter: z.string(),
 })
 
 const SanityDraftCourse = z.object({

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -64,6 +64,8 @@ const Tag = (props: any) => {
     }
   }, [scrollY])
 
+  console.log({author})
+
   return (
     <>
       <NextSeo
@@ -89,9 +91,9 @@ const Tag = (props: any) => {
       />
       <SocialProfileJsonLd
         type="Person"
-        name={author.name}
-        url={`https://egghead.io/q/resources-by-${author.slug.current}`}
-        sameAs={[author.twitter, author.website]}
+        name={author?.name}
+        url={`https://egghead.io/q/resources-by-${author?.slug?.current}`}
+        sameAs={[author?.twitter, author?.website]}
       />
       <ArticleJsonLd
         url={canonicalUrl}
@@ -99,8 +101,8 @@ const Tag = (props: any) => {
         images={[ogImage]}
         datePublished={publishedAt}
         dateModified={updatedAt}
-        authorName={author.name}
-        description={truncate(removeMarkdown(seo.description), {length: 155})}
+        authorName={author?.name}
+        description={truncate(removeMarkdown(seo?.description), {length: 155})}
         publisherName="egghead.io"
         publisherLogo="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1567198446/og-image-assets/eggo.svg"
       />

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -8,7 +8,7 @@ import {MDXRemote} from 'next-mdx-remote'
 import {FunctionComponent} from 'react'
 import Image from 'next/legacy/image'
 import Link from 'next/link'
-import {NextSeo} from 'next-seo'
+import {ArticleJsonLd, NextSeo, SocialProfileJsonLd} from 'next-seo'
 import {useRouter} from 'next/router'
 import CourseWidget from '@/components/mdx/course-widget'
 import ResourceWidget from '@/components/mdx/resource-widget'
@@ -18,6 +18,8 @@ import {useScrollTracker} from 'react-scroll-tracker'
 import analytics from '@/utils/analytics'
 import EmailSubscribeWidget from '@/components/mdx/email-subscribe-widget'
 import remarkGfm from 'remark-gfm'
+import truncate from 'lodash/truncate'
+import removeMarkdown from 'remove-markdown'
 
 function urlFor(source: any): any {
   return imageUrlBuilder(sanityClient).image(source)
@@ -35,6 +37,8 @@ const Tag = (props: any) => {
     articleResources,
     resources,
     slug,
+    updatedAt,
+    publishedAt,
   } = props
 
   const seo = originalSEO ? originalSEO : {}
@@ -82,6 +86,23 @@ const Tag = (props: any) => {
           handle: seo.handle,
         }}
         canonical={canonicalUrl}
+      />
+      <SocialProfileJsonLd
+        type="Person"
+        name={author.name}
+        url={`https://egghead.io/q/resources-by-${author.slug.current}`}
+        sameAs={[author.twitter, author.website]}
+      />
+      <ArticleJsonLd
+        url={canonicalUrl}
+        title={title}
+        images={[ogImage]}
+        datePublished={publishedAt}
+        dateModified={updatedAt}
+        authorName={author.name}
+        description={truncate(removeMarkdown(seo.description), {length: 155})}
+        publisherName="egghead.io"
+        publisherLogo="https://res.cloudinary.com/dg3gyk0gu/image/upload/v1567198446/og-image-assets/eggo.svg"
       />
       <div className="container">
         <article className="max-w-screen-md mx-auto mt-10 mb-16 lg:mt-24 md:mt-20">
@@ -210,6 +231,8 @@ const query = groq`*[_type == "post" && slug.current == $slug][0]{
   seo,
   coverImage,
   body,
+  publishedAt,
+  _updatedAt,
   "slug": slug.current,
   "articleResources": resources[type == "collection"]{
     "location": content[0].text,


### PR DESCRIPTION
With next-seo it's fairly easy to add this structured data to each page. Using `SocialProfileJsonLd` we can add the instructor which links their twitter and website provided to that page.

On course pages we can add `CourseJsonLd`. This adds the provider (egghead) with title and description.

Article pages get `ArticleJsonLd` that includes author, publish date, publisher name, title, description, and images.

Lesson pages already had `VideoJsonLd` but added `SocialProfileJsonLd` as well.