### PR TITLE
enhance pricing widget with yearly percernt off

### DIFF
--- a/src/components/pricing/select-plan-new/index.tsx
+++ b/src/components/pricing/select-plan-new/index.tsx
@@ -207,6 +207,41 @@ const GetAccessButton: React.FunctionComponent<
   )
 }
 
+const PlanPercentageOff: React.FunctionComponent<
+  React.PropsWithChildren<{interval: string}>
+> = ({interval}) => {
+  switch (interval) {
+    case 'Yearly':
+      return (
+        <div className="max-w-2xl pt-4 text-sm font-light leading-tight text-gray-700 dark:text-gray-200">
+          Best Value
+        </div>
+      )
+    case 'Quarterly':
+      return (
+        <div className="max-w-2xl pt-4 text-sm font-light leading-tight text-gray-700 dark:text-gray-200">
+          Save{' '}
+          <strong className="dark:bg-amber-400 dark:text-black bg-blue-600 text-white px-px font-semibold">
+            29%
+          </strong>{' '}
+          with yearly billing
+        </div>
+      )
+    case 'Monthly':
+      return (
+        <div className="max-w-2xl pt-4 text-sm font-light leading-tight text-gray-700 dark:text-gray-200">
+          Save{' '}
+          <strong className="dark:bg-amber-400 dark:text-black bg-blue-600 text-white px-px font-semibold">
+            50%
+          </strong>{' '}
+          with yearly billing
+        </div>
+      )
+    default:
+      return null
+  }
+}
+
 type SelectPlanProps = {
   prices: any
   pricesLoading: boolean
@@ -270,6 +305,7 @@ const SelectPlanNew: React.FunctionComponent<
             </div>
           )}
         </div>
+        {!appliedCoupon && <PlanPercentageOff interval={currentPlan.name} />}
         {quantityAvailable && (
           <div className="my-4">
             <PlanQuantitySelect
@@ -292,7 +328,6 @@ const SelectPlanNew: React.FunctionComponent<
         />
       </div>
       <ColoredBackground />
-      {currentPlan.interval === 'year' && <BestValueStamp />}
     </>
   )
 }


### PR DESCRIPTION
During a design session with @vojtaholik, we thought it would make a positive impact if we display the % savings of switching to a yearly plan would give a learner. 

This adds a switch statement that displays `Save X% with yearly billing` when people are on quarterly or monthly options.

What we display on the yearly plan could use some zhuzh 


(my local dev set up has weird pricing)
![monthly](https://github.com/skillrecordings/egghead-next/assets/6188161/ae06873f-3282-4418-b80e-ffe2566a39b8)
![quarterly](https://github.com/skillrecordings/egghead-next/assets/6188161/84088bed-79df-4262-864b-16186534889c)
![yearly](https://github.com/skillrecordings/egghead-next/assets/6188161/bec671a9-c282-426f-8254-68c6b42a33de)

![g savings](https://media3.giphy.com/media/d54lacgNCBUS4RkGG7/giphy.gif?cid=1927fc1b00i2b8wdb1lx55tv50bgo1bbpib6a8yn0slf6402&ep=v1_gifs_search&rid=giphy.gif&ct=g)