### PR TITLE
justify-center items on vertical cards

### DIFF
--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -65,7 +65,7 @@ const VerticalResourceCard: React.FC<
       <Card
         {...props}
         resource={resource}
-        className="justify-center rounded-md aspect-[3/4] w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 flex"
+        className="flex justify-center rounded-md aspect-[3/4] w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50"
       >
         {resource.background && (
           <Image

--- a/src/components/card/new-vertical-resource-card.tsx
+++ b/src/components/card/new-vertical-resource-card.tsx
@@ -65,7 +65,7 @@ const VerticalResourceCard: React.FC<
       <Card
         {...props}
         resource={resource}
-        className="rounded-md aspect-[3/4] w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 flex"
+        className="justify-center rounded-md aspect-[3/4] w-full h-full transition-all ease-in-out duration-200 relative overflow-hidden group dark:bg-gray-800 bg-white dark:bg-opacity-60 shadow-smooth dark:hover:bg-gray-700 dark:hover:bg-opacity-50 flex"
       >
         {resource.background && (
           <Image


### PR DESCRIPTION
When titles leave room for horizontal space the contents of vertical cards aren't centered properly. This adds `justify-center` to properly position content inside a card

![g crooked](https://media4.giphy.com/media/3ohhwlF6avYNoQJ83e/giphy.gif?cid=1927fc1b67a2dkn6vt3bkhgkypy2ey8tuc901oo6beznpizs&ep=v1_gifs_search&rid=giphy.gif&ct=g)

![not centered](https://github.com/skillrecordings/egghead-next/assets/6188161/f0990967-0209-4174-862d-611d32ec0f05)
 
![centered](https://github.com/skillrecordings/egghead-next/assets/6188161/b755ef7f-0575-4afe-aa73-3cbff20710dd)
