### PR TITLE
fix SEO structured data errors

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -403,7 +403,9 @@ const CollectionPageLayout: React.FunctionComponent<
   return (
     <>
       <NextSeo
-        description={truncate(removeMarkdown(description), {length: 155})}
+        description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
+          length: 155,
+        })}
         canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`}
         title={title}
         titleTemplate={'%s | egghead.io'}
@@ -415,7 +417,10 @@ const CollectionPageLayout: React.FunctionComponent<
         openGraph={{
           title,
           url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`,
-          description: truncate(removeMarkdown(description), {length: 155}),
+          description: truncate(
+            removeMarkdown(description.replace(/"/g, "'")),
+            {length: 155},
+          ),
           site_name: 'egghead',
           images: [
             {
@@ -429,12 +434,6 @@ const CollectionPageLayout: React.FunctionComponent<
         name={name}
         url={`https://egghead.io/q/resources-by-${slug}`}
         sameAs={[twitter, instructor.website]}
-      />
-      <CourseJsonLd
-        courseName={title}
-        providerName="egghead.io"
-        providerUrl="https://egghead.io"
-        description={truncate(removeMarkdown(description), {length: 155})}
       />
       <div className="container pb-8 sm:pb-16 dark:text-gray-100">
         {state === 'retired' && (

--- a/src/components/layouts/draft-course-page-layout.tsx
+++ b/src/components/layouts/draft-course-page-layout.tsx
@@ -63,7 +63,9 @@ const DraftCourseLayout: React.FunctionComponent<
   return (
     <>
       <NextSeo
-        description={truncate(removeMarkdown(description), {length: 155})}
+        description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
+          length: 155,
+        })}
         title={title}
         titleTemplate={'%s | egghead.io'}
         twitter={{
@@ -72,7 +74,10 @@ const DraftCourseLayout: React.FunctionComponent<
         }}
         openGraph={{
           title,
-          description: truncate(removeMarkdown(description), {length: 155}),
+          description: truncate(
+            removeMarkdown(description.replace(/"/g, "'")),
+            {length: 155},
+          ),
           site_name: 'egghead',
         }}
       />

--- a/src/components/layouts/multi-module-collection-page-layout.tsx
+++ b/src/components/layouts/multi-module-collection-page-layout.tsx
@@ -403,7 +403,9 @@ const MultiModuleCollectionPageLayout: React.FunctionComponent<
   return (
     <>
       <NextSeo
-        description={truncate(removeMarkdown(description), {length: 155})}
+        description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
+          length: 155,
+        })}
         canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`}
         title={title}
         titleTemplate={'%s | egghead.io'}
@@ -415,7 +417,10 @@ const MultiModuleCollectionPageLayout: React.FunctionComponent<
         openGraph={{
           title,
           url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`,
-          description: truncate(removeMarkdown(description), {length: 155}),
+          description: truncate(
+            removeMarkdown(description.replace(/"/g, "'")),
+            {length: 155},
+          ),
           site_name: 'egghead',
           images: [
             {

--- a/src/components/pages/lessons/lesson/index.tsx
+++ b/src/components/pages/lessons/lesson/index.tsx
@@ -492,7 +492,7 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
           length: 155,
         })}
         canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${lesson.path}`}
-        title={title}
+        title={title.replace(/"/g, "'")}
         titleTemplate={'%s | egghead.io'}
         twitter={{
           handle: instructor?.twitter,
@@ -500,7 +500,7 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
           cardType: 'summary_large_image',
         }}
         openGraph={{
-          title,
+          title: title.replace(/"/g, "'"),
           url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${lesson.path}`,
           description: truncate(
             removeMarkdown(description.replace(/"/g, "'")),
@@ -515,7 +515,7 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
         }}
       />
       <VideoJsonLd
-        name={title}
+        name={title.replace(/"/g, "'")}
         description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
           length: 155,
         })}

--- a/src/components/pages/lessons/lesson/index.tsx
+++ b/src/components/pages/lessons/lesson/index.tsx
@@ -488,7 +488,9 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
   return (
     <>
       <NextSeo
-        description={truncate(removeMarkdown(description), {length: 155})}
+        description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
+          length: 155,
+        })}
         canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${lesson.path}`}
         title={title}
         titleTemplate={'%s | egghead.io'}
@@ -500,7 +502,10 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
         openGraph={{
           title,
           url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${lesson.path}`,
-          description: truncate(removeMarkdown(description), {length: 155}),
+          description: truncate(
+            removeMarkdown(description.replace(/"/g, "'")),
+            {length: 155},
+          ),
           site_name: 'egghead',
           images: [
             {
@@ -511,7 +516,9 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
       />
       <VideoJsonLd
         name={title}
-        description={truncate(removeMarkdown(description), {length: 155})}
+        description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
+          length: 155,
+        })}
         uploadDate={lesson?.created_at}
         thumbnailUrls={compact([lesson?.thumb_url])}
       />


### PR DESCRIPTION
Saw some errors in the Google Search Console that are quick fixes

## `Parsing error: Missing ',' or '}'` 
any lesson or course that has `""` in the description is erroring out because we don't escape the quote mark. Swapped the double quote for single quote to fix.

 ## `Course info`
Courses have 2 main errors which looks like `next-seo` doesn't support this structured data well. 
- `Missing field "hasCourseInstance"`
- `Missing field "offers"`
`hasCourseInstance` is looking for a place the course is being hosted, looks like 'online' is an option. `offers` is looking for a price which I'm not sure how to gauge for our courses. 

`next-seo` is throwing errors as it doesn't expect this data so I'm opting to remove the structured data for now to resolve errors.

![g fixed](https://media3.giphy.com/media/0kh68QQogGIUC6MTu7/giphy.gif?cid=1927fc1bnn9ipllifal4j0ntpozt7wqiqm7qo2da2q2fplm1&ep=v1_gifs_search&rid=giphy.gif&ct=g)
