### PR TITLE
Zj/restructure course lesson headings

### DIFF
--- a/src/components/app/app-footer.tsx
+++ b/src/components/app/app-footer.tsx
@@ -186,9 +186,9 @@ const DarkModeToggle = () => {
   }
   return (
     <div className="flex items-center justify-between">
-      <h2 className="hidden mr-3 sm:block">
+      <span className="hidden mr-3 sm:block">
         {resolvedTheme === 'dark' ? 'Dark' : 'Light'} Mode
-      </h2>
+      </span>
       <div
         className="flex-shrink-0 w-16 h-10 p-1 bg-gray-300 rounded-full dark:bg-gray-1000"
         onClick={handleClick}

--- a/src/components/app/footer.tsx
+++ b/src/components/app/footer.tsx
@@ -186,9 +186,9 @@ const DarkModeToggle = () => {
   }
   return (
     <div className="flex items-center justify-between">
-      <h2 className="hidden mr-3 sm:block">
+      <span className="hidden mr-3 sm:block">
         {resolvedTheme === 'dark' ? 'Dark' : 'Light'} Mode
-      </h2>
+      </span>
       <div
         className="flex-shrink-0 w-16 h-10 p-1 bg-gray-300 rounded-full dark:bg-gray-1000"
         onClick={handleClick}

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -8,6 +8,7 @@ type DialogProps = {
   title: string
   buttonText: string
   buttonStyles: string
+  disabled: boolean | undefined
 }
 const Dialog: FunctionComponent<React.PropsWithChildren<DialogProps>> = ({
   children,
@@ -15,13 +16,14 @@ const Dialog: FunctionComponent<React.PropsWithChildren<DialogProps>> = ({
   title,
   buttonText,
   buttonStyles = '',
+  disabled = false,
 }) => {
   const [showDialog, setShowDialog] = React.useState(false)
   const open = () => setShowDialog(true)
   const close = () => setShowDialog(false)
   return (
     <div>
-      <button onClick={open} className={buttonStyles}>
+      <button disabled={disabled} onClick={open} className={buttonStyles}>
         {buttonText}
       </button>
       <DialogOverlay isOpen={showDialog} onDismiss={close}>

--- a/src/components/pages/courses/instructor-profile.tsx
+++ b/src/components/pages/courses/instructor-profile.tsx
@@ -21,14 +21,14 @@ const InstructorProfile: React.FunctionComponent<
         }}
       />
       <div className="ml-2 flex flex-col justify-center">
-        <h4 className="text-gray-700 dark:text-gray-400 text-sm leading-tighter">
+        <span className="text-gray-700 dark:text-gray-400 text-sm leading-tighter">
           Instructor
-        </h4>
+        </span>
         <Link
           href={`/q/resources-by-${url}`}
           className="flex hover:underline flex-shrink-0"
         >
-          <span className="font-semibold text-base">{name}</span>
+          <h2 className="font-semibold text-base">{name}</h2>
         </Link>
       </div>
     </div>

--- a/src/components/pages/lessons/comments/comment-field/index.tsx
+++ b/src/components/pages/lessons/comments/comment-field/index.tsx
@@ -4,14 +4,16 @@ import Spinner from '@/components/spinner'
 import {useVideo} from '@skillrecordings/player'
 import Dialog from '@/components/dialog'
 import ReactMarkdown from 'react-markdown'
+import {disable} from 'mixpanel-browser'
 
 type CommentFieldProps = {
   onSubmit?: any
+  disabled?: boolean
 }
 
 const CommentField: FunctionComponent<
   React.PropsWithChildren<CommentFieldProps>
-> = ({onSubmit = () => {}}) => {
+> = ({onSubmit = () => {}, disabled}) => {
   const [isSubmitted, setIsSubmitted] = React.useState(false)
   const [isError, setIsError] = React.useState(false)
   const videoService = useVideo()
@@ -55,7 +57,7 @@ const CommentField: FunctionComponent<
                     onChange={handleChange}
                     onBlur={handleBlur}
                     placeholder="Your comment..."
-                    disabled={isSubmitting}
+                    disabled={disabled || isSubmitting}
                     className={`min-h-[120px] form-textarea p-3 dark:text-white dark:bg-gray-800 text-gray-900 placeholder-gray-400 focus:ring-indigo-500 focus:border-blue-500 block w-full border-gray-300 dark:border-gray-700 rounded-md resize-none ${
                       isSubmitting ? 'opacity-60' : ''
                     }`}
@@ -64,7 +66,7 @@ const CommentField: FunctionComponent<
                   <div className="flex justify-between items-center">
                     <button
                       type="submit"
-                      disabled={isSubmitting}
+                      disabled={disabled || isSubmitting}
                       className={`w-32 flex items-center justify-center transition-all text-sm duration-150 ease-in-out bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md ${
                         isSubmitting
                           ? 'cursor-not-allowed opacity-60'
@@ -90,6 +92,7 @@ const CommentField: FunctionComponent<
                     ariaLabel="open comment guidelines"
                     title="Comment Guidelines"
                     buttonStyles=""
+                    disabled={disabled}
                   >
                     <div className="prose dark:prose-dark dark:prose-a:text-blue-300 prose-a:text-blue-500 max-w-none mt-1">
                       <ReactMarkdown

--- a/src/components/pages/lessons/comments/comments/index.tsx
+++ b/src/components/pages/lessons/comments/comments/index.tsx
@@ -95,7 +95,7 @@ const Comments: React.FunctionComponent<
         <CommentField onSubmit={handleCommentSubmission} />
       ) : (
         <div className="relative flex flex-col dark:text-white">
-          <CommentField onSubmit={() => {}} />
+          <CommentField disabled onSubmit={() => {}} />
 
           <div className="absolute backdrop-blur-sm bg-gray-50/20 dark:bg-black/20 p-8 w-[105%] h-[105%] -top-1 -right-1 flex flex-col justify-center items-center gap-4">
             <span className="font-semibold flex gap-2 justify-center">

--- a/src/components/pages/lessons/comments/comments/index.tsx
+++ b/src/components/pages/lessons/comments/comments/index.tsx
@@ -98,10 +98,10 @@ const Comments: React.FunctionComponent<
           <CommentField onSubmit={() => {}} />
 
           <div className="absolute backdrop-blur-sm bg-gray-50/20 dark:bg-black/20 p-8 w-[105%] h-[105%] -top-1 -right-1 flex flex-col justify-center items-center gap-4">
-            <h4 className="font-semibold flex gap-2 justify-center">
+            <span className="font-semibold flex gap-2 justify-center">
               <LockClosedIcon height={20} width={20} /> Become a member to join
               the discussion
-            </h4>
+            </span>
             <Link
               href="/pricing"
               onClick={() =>

--- a/src/components/pages/lessons/overlay/email-capture-cta-overlay.tsx
+++ b/src/components/pages/lessons/overlay/email-capture-cta-overlay.tsx
@@ -34,23 +34,23 @@ const EmailCaptureCtaOverlay: FunctionComponent<
         >
           <div className="text-center">
             {collection ? (
-              <h1 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
+              <h2 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
                 Ready to finish{' '}
                 <strong className="font-bold">{collection.title}</strong>?
-              </h1>
+              </h2>
             ) : (
-              <h1 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
+              <h2 className="text-xl md:text-2xl lg:text-xl xl:text-3xl leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
                 Unlock this free lesson!
-              </h1>
+              </h2>
             )}
 
-            <h2 className="pt-4 text-lg leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
+            <h3 className="pt-4 text-lg leading-tighter tracking-tight font-light text-center max-w-xl mx-auto">
               This lesson (and hundreds more!) by awesome instructors like{' '}
               <br />
               {lesson.instructor.full_name} are{' '}
               <strong className="font-bold">free to watch</strong> with your
               egghead account.
-            </h2>
+            </h3>
             <p className="font-normal text-blue-300 text-base sm:text-md lg:text-base xl:text-md mt-4">
               Enter your email to unlock this free lesson.
             </p>

--- a/src/components/player/player-sidebar.tsx
+++ b/src/components/player/player-sidebar.tsx
@@ -163,9 +163,9 @@ const CourseHeader: React.FunctionComponent<
         />
       </div>
       <div className="ml-2 lg:ml-4">
-        <h4 className="mb-px text-xs font-semibold text-gray-700 uppercase dark:text-gray-100">
+        <span className="mb-px text-xs font-semibold text-gray-700 uppercase dark:text-gray-100">
           Course
-        </h4>
+        </span>
         <Link href={course.path}>
           <a
             onClick={() => {
@@ -175,9 +175,9 @@ const CourseHeader: React.FunctionComponent<
             }}
             className="hover:underline"
           >
-            <h3 className="font-bold leading-tighter 2xl:text-lg">
+            <h2 className="font-bold leading-tighter 2xl:text-lg">
               {course.title}
-            </h3>
+            </h2>
           </a>
         </Link>
       </div>
@@ -206,9 +206,9 @@ const TagHeader: React.FunctionComponent<
         />
       </div>
       <div className="ml-2 lg:ml-4">
-        <h4 className="mb-px text-xs font-semibold text-gray-700 uppercase dark:text-gray-100">
+        <span className="mb-px text-xs font-semibold text-gray-700 uppercase dark:text-gray-100">
           Tag
-        </h4>
+        </span>
         <Link href={`/q/${tag.name}`}>
           <a
             onClick={() => {
@@ -218,9 +218,9 @@ const TagHeader: React.FunctionComponent<
             }}
             className="hover:underline"
           >
-            <h3 className="font-bold leading-tighter 2xl:text-lg">
+            <h2 className="font-bold leading-tighter 2xl:text-lg">
               Lessons Related to {tag.label}
-            </h3>
+            </h2>
           </a>
         </Link>
       </div>

--- a/src/components/share.tsx
+++ b/src/components/share.tsx
@@ -22,7 +22,10 @@ const Share: FunctionComponent<React.PropsWithChildren<ShareProps>> = ({
 }) => {
   return (
     <>
-      <h4 className="text-sm">{children || title}</h4>
+      <span className="text-sm">{children || title}</span>
+      <h2 sr-only className="sr-only">
+        Social Share Links
+      </h2>
       <div className={className || 'flex items-center mt-3'}>
         <div className={'flex items-center space-x-2'}>
           <TweetLink resource={resource} instructor={instructor} />


### PR DESCRIPTION

![g tree grow](https://media2.giphy.com/media/Vi5TUmZz8LZb95j2xb/giphy.gif?cid=1927fc1bh79kzd7d4y2v04bmmdq8ipievbozt639uth8av12&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## (before) Heading issues on course and lesson pages
- Skipped a heading for `instructor`
- dark mode toggle is not important to the page
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/6ec0bad3-f3cb-47d5-bca2-332d6a98a097)

- two h1's when the email capture overlay is present
- skipping heading #

![image](https://github.com/skillrecordings/egghead-next/assets/6188161/22acfd5d-b79e-4b17-bbcc-abd5ce87532b)


## (fixed) headings
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/cc1806e2-198b-4c08-8212-22ee3940e57c)

- h1 is half way down the document which I'm not sure how to fix or if that's an issue
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/d9529984-208c-437d-a141-d7b12fb14278)
