### PR TITLE
fix: add contentUrl and duration to structured video data

### DIFF
--- a/src/components/pages/lessons/lesson/index.tsx
+++ b/src/components/pages/lessons/lesson/index.tsx
@@ -519,6 +519,8 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
         description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
           length: 155,
         })}
+        contentUrl={lesson?.hls_url}
+        duration={lesson?.duration}
         uploadDate={lesson?.created_at}
         thumbnailUrls={compact([lesson?.thumb_url])}
       />


### PR DESCRIPTION
the `contentUrl` for videos is getting set to some random string (uuid?) on lesson pages which will 404. This sets content URL to the `hls_url` which is an [accepted format for google](https://developers.google.com/search/docs/appearance/video#supported-video-encodings)



[content url is recommended](https://developers.google.com/search/docs/appearance/structured-data/video#structured-data-type-definitions)
![image](https://github.com/skillrecordings/egghead-next/assets/6188161/17663fdd-581e-4a05-aadf-638d41e10a76)


![image](https://github.com/skillrecordings/egghead-next/assets/6188161/42bf06ed-7310-404a-8352-c6376dfbbd25)


![g index me](https://media0.giphy.com/media/JieoXejYRg8fK/giphy.gif?cid=1927fc1bxsonfipfih7lobhix4e7vyv8ha4kzn5o4ybp1xft&ep=v1_gifs_search&rid=giphy.gif&ct=g)