### PR TITLE
convert to iso8601 for videojsonld

### DIFF
--- a/src/components/pages/lessons/lesson/index.tsx
+++ b/src/components/pages/lessons/lesson/index.tsx
@@ -82,6 +82,15 @@ const MAX_FREE_VIEWS = 4
 
 const notesEnabled = process.env.NEXT_PUBLIC_NOTES_ENABLED === 'true'
 
+function toISO8601Duration(duration: number) {
+  const seconds = Math.floor(duration % 60)
+  const minutes = Math.floor((duration / 60) % 60)
+  const hours = Math.floor((duration / (60 * 60)) % 24)
+  const days = Math.floor(duration / (60 * 60 * 24))
+
+  return `P${days}DT${hours}H${minutes}M${seconds}S`
+}
+
 const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
   initialLesson,
   state,
@@ -520,7 +529,7 @@ const Lesson: React.FC<React.PropsWithChildren<LessonProps>> = ({
           length: 155,
         })}
         contentUrl={lesson?.hls_url}
-        duration={lesson?.duration}
+        duration={toISO8601Duration(Number(lesson?.duration ?? 0))}
         uploadDate={lesson?.created_at}
         thumbnailUrls={compact([lesson?.thumb_url])}
       />


### PR DESCRIPTION
Google is looking for ISO 8601 format for duration with structured video data

![image](https://github.com/skillrecordings/egghead-next/assets/6188161/ebd884e5-a715-4bdd-86ec-3c78bc979619)

![g structure](https://media4.giphy.com/media/CaaQxoAktdZCbDSLqJ/giphy.gif?cid=1927fc1b2t6af9wx7fe2k0ipysof1k0i8pvtrudlt32xpq3n&ep=v1_gifs_search&rid=giphy.gif&ct=g)
