### PR TITLE
feedback widget returns 401 unauthorized

### DIFF
--- a/src/app/api/slack/feedback/route.ts
+++ b/src/app/api/slack/feedback/route.ts
@@ -1,0 +1,49 @@
+import {NextRequest} from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  const {feedback} = body
+
+  let response = await fetch(process.env.SLACK_FEEDBACK_URL ?? '', {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      attachments: [
+        {
+          color: '#2EB67D',
+          blocks: [
+            {
+              type: 'divider',
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: feedback?.url,
+              },
+            },
+
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `*[${feedback?.site}] ${feedback?.emotion} ${feedback?.category} feedback was sent by ${feedback?.user?.email}* \n\n ${feedback?.comment}`,
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  })
+
+  if (response?.status !== 200) {
+    throw new Error('error occured, feedback not sent')
+  }
+
+  return new Response('feedback sent', {
+    status: 200,
+  })
+}

--- a/src/app/api/slack/feedback/route.ts
+++ b/src/app/api/slack/feedback/route.ts
@@ -1,9 +1,7 @@
 import {NextRequest} from 'next/server'
 
 export async function POST(req: NextRequest) {
-  const body = await req.json()
-
-  const {feedback} = body
+  const {feedback} = await req.json()
 
   let response = await fetch(process.env.SLACK_FEEDBACK_URL ?? '', {
     method: 'POST',

--- a/src/components/feedback-input/index.tsx
+++ b/src/components/feedback-input/index.tsx
@@ -15,6 +15,7 @@ import Sob from './images/Sob'
 import Hearteyes from './images/Hearteyes'
 import NeutralFace from './images/NeutralFace'
 import useCio from '@/hooks/use-cio'
+import {getAuthorizationHeader} from '@/utils/auth'
 
 type FeedbackCategory = {
   id: number
@@ -218,8 +219,13 @@ const Feedback: FunctionComponent<React.PropsWithChildren<FeedbackProps>> = ({
 
     setState({loading: true, success: false, errorMessage: null})
     actions.setSubmitting(true)
-    axios
-      .post('/api/v1/feedback', {
+    fetch('/api/slack/feedback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getAuthorizationHeader(),
+      },
+      body: JSON.stringify({
         feedback: {
           url: window.location.toString(),
           site: `egghead-next`,
@@ -228,7 +234,8 @@ const Feedback: FunctionComponent<React.PropsWithChildren<FeedbackProps>> = ({
           user: user,
           emotion: slackEmojiCode,
         },
-      })
+      }),
+    })
       .then(() => {
         analytics.events.engagementSentFeedback(
           selectedCategory.category,


### PR DESCRIPTION
In the spirit of using less rails API, instead of figuring out why rails was returning a `401` I opted for migrating functionality to an API route that posts message to slack directly. 

We'll need to set `SLACK_FEEDBACK_URL` as an environment variable in vercel before this is merged

the message it posts: 

![image](https://github.com/skillrecordings/egghead-next/assets/6188161/8165b632-1430-4c4a-936f-c74ab1d96f7b)


![g cool](https://media0.giphy.com/media/lrDMG46JjKiovLbkn8/giphy.gif?cid=1927fc1b923fovm19vgk1yr7t4ow5req9sohec50cx3ybw2y&ep=v1_gifs_search&rid=giphy.gif&ct=g)