### PR TITLE
Rate limit search page to 60 requests a minute

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "load-script": "^1.0.0",
     "lodash": "^4.17.21",
     "logrocket": "^2.0.0",
+    "lru-cache": "^10.2.0",
     "lucide-react": "^0.274.0",
     "mdast-util-to-markdown": "^0.6.5",
     "mdx-bundler": "9.2.1",

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -1,0 +1,31 @@
+import {LRUCache} from 'lru-cache'
+
+const rateLimit = (options) => {
+  const tokenCache = new LRUCache({
+    max: parseInt(options.uniqueTokenPerInterval || 500, 10),
+    maxAge: parseInt(options.interval || 60000, 10),
+  })
+
+  return {
+    check: (res, limit, token) =>
+      new Promise((resolve, reject) => {
+        const tokenCount = tokenCache.get(token) || [0]
+        if (tokenCount[0] === 0) {
+          tokenCache.set(token, tokenCount)
+        }
+        tokenCount[0] += 1
+
+        const currentUsage = tokenCount[0]
+        const isRateLimited = currentUsage >= parseInt(limit, 10)
+        res.setHeader('X-RateLimit-Limit', limit)
+        res.setHeader(
+          'X-RateLimit-Remaining',
+          isRateLimited ? 0 : limit - currentUsage,
+        )
+
+        return isRateLimited ? reject() : resolve()
+      }),
+  }
+}
+
+export default rateLimit

--- a/src/utils/search/topic-extractor.ts
+++ b/src/utils/search/topic-extractor.ts
@@ -2,8 +2,8 @@ import {QueryReturnType} from '@/lib/search-url-builder'
 import {first, isEmpty} from 'lodash'
 
 export const topicExtractor = (searchState: QueryReturnType) => {
-  if (!isEmpty(searchState.refinementList?._tags)) {
-    return searchState.refinementList?._tags
+  if (!isEmpty(searchState?.refinementList?._tags)) {
+    return searchState?.refinementList?._tags
   }
   const selectedTopics = []
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24721,13 +24721,8 @@ vscode-textmate@^8.0.0:
   resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
   integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
-"vscode-textmate@git+https://github.com/octref/vscode-textmate.git":
-  version "4.0.1"
-  resolved "git+https://github.com/octref/vscode-textmate.git#e65aabe2227febda7beaad31dd0fca1228c5ddf3"
-
 "vscode-textmate@https://github.com/octref/vscode-textmate":
   version "4.0.1"
-  uid e65aabe2227febda7beaad31dd0fca1228c5ddf3
   resolved "https://github.com/octref/vscode-textmate#e65aabe2227febda7beaad31dd0fca1228c5ddf3"
 
 w3c-hr-time@^1.0.2:


### PR DESCRIPTION
I picked 60 requests a minute but not sure if that should be lowered at all.

This follows vercel's [rate limiting example](https://github.com/vercel/next.js/pull/19509/files). Because the use-case is simple, I opted for this over introducing [upstash ratelimit](https://github.com/upstash/ratelimit)

![g stop](https://media0.giphy.com/media/zCpYQh5YVhdI1rVYpE/giphy.gif?cid=1927fc1bzenygoiivyq45wihtgx6jxrxnizcd4fkbynbkjyq&ep=v1_gifs_search&rid=giphy.gif&ct=g)