### PR TITLE
prefer SEND_SLACK_MESSAGE_EVENT to send slack message

### DIFF
--- a/src/inngest/functions/tip-video-uploaded.ts
+++ b/src/inngest/functions/tip-video-uploaded.ts
@@ -105,29 +105,6 @@ export const tipVideoUploaded = inngest.createFunction(
           })
           .commit()
       })
-
-      if (eggheadInstructor?.slack_group_id) {
-        await step.run('announce tip created', async () => {
-          const channel = eggheadInstructor.slack_group_id
-          return postToSlack({
-            channel,
-            username: 'Tip Robot',
-            text: `Tip Ready for Review`,
-            attachments: [
-              {
-                mrkdwn_in: ['text'],
-                title_link: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}/tips/${tip._id}`,
-                text: tip.body,
-                color: '#f17f08',
-                title: tip.title,
-              },
-            ],
-          }).catch((e) => {
-            console.error(e)
-            return e
-          })
-        })
-      }
     }
 
     // TODO add partykit later


### PR DESCRIPTION
We are getting double messages for instructors who upload tips. We have a `SEND_SLACK_MESSAGE_EVENT` now that we are using so removing this second call to post a slack message

![g double trouble](https://media2.giphy.com/media/26hisBivAHsOlWfx6/giphy.gif?cid=1927fc1b3x943v8cdn7uvnl249a46rvg5cxkimfc4dc6skgm&ep=v1_gifs_search&rid=giphy.gif&ct=g)