### PR TITLE
safely access course description

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -403,7 +403,7 @@ const CollectionPageLayout: React.FunctionComponent<
   return (
     <>
       <NextSeo
-        description={truncate(removeMarkdown(description.replace(/"/g, "'")), {
+        description={truncate(removeMarkdown(description?.replace(/"/g, "'")), {
           length: 155,
         })}
         canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`}
@@ -418,7 +418,7 @@ const CollectionPageLayout: React.FunctionComponent<
           title,
           url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`,
           description: truncate(
-            removeMarkdown(description.replace(/"/g, "'")),
+            removeMarkdown(description?.replace(/"/g, "'")),
             {length: 155},
           ),
           site_name: 'egghead',


### PR DESCRIPTION
on the very rare occasion we don't have a course description set, the course page crashes because we were calling `.replace` as such: `description.replace(/"/g, "'")`

![g oops](https://media1.giphy.com/media/BsQAVgY6ksvIY/giphy.gif?cid=1927fc1bunjm2tn1ixgo7byzfbx71xn7gop4nub7vszpky3j&ep=v1_gifs_search&rid=giphy.gif&ct=g)