### PR TITLE
Fix max-width for paragraph in dialogs

### DIFF
--- a/src/components/pages/courses/membership-dialog-button.tsx
+++ b/src/components/pages/courses/membership-dialog-button.tsx
@@ -11,9 +11,7 @@ const MembershipDialogButton = ({title, children, buttonText}: any) => {
       buttonStyles="text-gray-600 dark:text-gray-300 flex flex-row items-center rounded hover:bg-gray-100 
         dark:hover:bg-gray-700 border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-600 px-4 py-2 border transition-colors text-sm xs:text-base ease-in-out opacity-90 shadow-sm"
     >
-      <p className="max-w-10 text-center text-gray-700 dark:text-gray-400">
-        {children}
-      </p>
+      <p className="text-center text-gray-700 dark:text-gray-400">{children}</p>
       <p className="uppercase text-sm tracking-wide dark:text-gray-300 text-gray-500 font-semibold text-center border-t border-gray-200 dark:border-gray-700 pt-5">
         Membership includes
       </p>


### PR DESCRIPTION
<details>
  <summary>Before</summary>
  <img width="1200" src="https://github.com/skillrecordings/egghead-next/assets/1519448/eca2b174-a6ef-48a6-a009-b71cbaf8e8c7">
  <img width="1200" src="https://github.com/skillrecordings/egghead-next/assets/1519448/8a4bd78f-93c8-405b-9e12-704357931344">
</details>
<details>
  <summary>After</summary>
  <img width="1200" src="https://github.com/skillrecordings/egghead-next/assets/1519448/b1ff8dbe-dcf0-48ba-90e2-ee159143a256">
  <img width="1200" src="https://github.com/skillrecordings/egghead-next/assets/1519448/696066c8-da3f-4d00-b0fd-9b0c469a589b">
</details>



![measuring tape measure up GIF](https://github.com/skillrecordings/egghead-next/assets/1519448/e07413cf-f4df-4829-8f83-89855f8b9665)



