### PR TITLE
Restyle article index and pages without cover images

### DIFF
--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -114,7 +114,7 @@ const Tag = (props: any) => {
       <div className="container">
         <article className="max-w-screen-md mx-auto mt-10 mb-16 lg:mt-24 md:mt-20">
           <header>
-            <h1 className="w-full max-w-screen-mdtext-3xl font-extrabold lg:text-6xl md:text-5xl sm:text-4xl pb-14 pt-24 sm:pb-24 sm:pt-32 leading-tighter">
+            <h1 className="w-full max-w-screen-mdtext-3xl font-extrabold lg:text-6xl md:text-5xl sm:text-4xl text-2xl pb-10 pt-16 sm:pb-24 sm:pt-32 leading-tighter">
               {title}
             </h1>
             <div className="flex justify-between items-center">

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -20,6 +20,11 @@ import EmailSubscribeWidget from '@/components/mdx/email-subscribe-widget'
 import remarkGfm from 'remark-gfm'
 import truncate from 'lodash/truncate'
 import removeMarkdown from 'remove-markdown'
+import friendlyTime from 'friendly-time'
+
+const UpdatedAt: React.FunctionComponent<
+  React.PropsWithChildren<{date: string}>
+> = ({date}) => <div>{date}</div>
 
 function urlFor(source: any): any {
   return imageUrlBuilder(sanityClient).image(source)
@@ -109,24 +114,22 @@ const Tag = (props: any) => {
       <div className="container">
         <article className="max-w-screen-md mx-auto mt-10 mb-16 lg:mt-24 md:mt-20">
           <header>
-            <h1 className="w-full max-w-screen-md mb-8 text-3xl font-extrabold lg:text-6xl md:text-5xl sm:text-4xl lg:mb-10 leading-tighter">
+            <h1 className="w-full max-w-screen-mdtext-3xl font-extrabold lg:text-6xl md:text-5xl sm:text-4xl pb-14 pt-24 sm:pb-24 sm:pt-32 leading-tighter">
               {title}
             </h1>
-            {author && <Author author={author} />}
-            {coverImage?.url && (
-              <div className="mt-4">
-                <Image
-                  src={coverImage.url}
-                  alt={coverImage.alt || title}
-                  width={1280}
-                  height={720}
-                  quality={100}
-                  className="rounded-lg"
-                />
+            <div className="flex justify-between items-center">
+              {author && <Author author={author} />}
+              <div className="flex flex-col w-40 text-sm leading-tighter justify-between">
+                <span className="uppercase text-xs">Published</span>
+                {publishedAt && (
+                  <div className="font-semibold place-content-end opacity-90">
+                    <UpdatedAt date={friendlyTime(new Date(publishedAt))} />
+                  </div>
+                )}
               </div>
-            )}
+            </div>
           </header>
-          <main className="prose dark:prose-dark sm:prose-lg lg:prose-xl max-w-none dark:prose-a:text-blue-300 prose-a:text-blue-500">
+          <main className="prose dark:prose-dark sm:prose-lg lg:prose-xl max-w-none dark:prose-a:text-blue-300 prose-a:text-blue-500 py-8">
             <MDXRemote
               {...source}
               components={{

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -32,69 +32,56 @@ const Blog: React.FC<React.PropsWithChildren<unknown>> = (allArticles: any) => {
             {allArticles.allArticles.map((article: any) => {
               const fullSlug = `/blog/${article.slug.current}`
               return (
-                <div key={fullSlug} className="flex flex-col">
-                  {article.coverImage?.url ? (
-                    <div className="mb-2 md:mb-4">
-                      <Link href={fullSlug}>
-                        <Image
-                          src={article.coverImage.url}
-                          alt={article.coverImage.alt || article.title}
-                          width={1280}
-                          height={720}
-                          quality={100}
-                          className="rounded-lg"
-                        />
-                      </Link>
-                    </div>
-                  ) : (
-                    <div className="mb-2 md:mb-4 aspect-[16/9] flex">
-                      <Link href={fullSlug}>
-                        <div className="absolute top-0 left-0 flex items-center justify-center w-full h-full text-gray-400 bg-gray-200 rounded-lg dark:bg-gray-800 dark:text-gray-600">
-                          <IconPlaceholder />
-                        </div>
-                      </Link>
-                    </div>
-                  )}
-                  <Link href={fullSlug}>
-                    <h2 className="text-xl font-bold md:text-2xl leading-tighter">
+                <Link href={fullSlug}>
+                  <div
+                    key={fullSlug}
+                    className="flex h-full flex-col justify-between rounded-lg border border-gray-100 px-5 py-8 dark:border-gray-800 md:px-8 hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-all ease-in-out"
+                  >
+                    <h2 className="text-balance text-2xl font-bold">
                       {article.title}
                     </h2>
-                  </Link>
 
-                  {article.author && (
-                    <div className="flex items-start mt-4 text-sm">
-                      <div className="flex items-center space-x-3">
-                        <Image
-                          src={article.author.image}
-                          alt={article.author.name}
-                          quality={100}
-                          width={40}
-                          height={40}
-                          className="rounded-full"
-                        />
-                        <div className="flex flex-col w-40">
-                          <div className="flex-none leading-tight opacity-90">
-                            {article.author.name}
-                          </div>
-                          {article.publishedAt && (
-                            <div className="leading-tight text-gray-500 place-content-end opacity-90">
-                              <UpdatedAt
-                                date={friendlyTime(
-                                  new Date(article.publishedAt),
-                                )}
-                              />
-                            </div>
-                          )}
-                        </div>
+                    {article.description && (
+                      <div className="line-clamp-3 w-full pt-3 text-gray-600 dark:text-gray-400">
+                        {article.description}
                       </div>
-                      {article.description && (
-                        <div className="pl-2 text-sm leading-snug opacity-70">
-                          {article.description}
+                    )}
+                    <div className="relative z-10 flex w-full flex-col items-start justify-between space-y-10 pt-8 md:flex-row md:items-center md:space-y-0">
+                      {article.author && (
+                        <div className="flex w-full items-center gap-10 text-sm text-gray-700 dark:text-gray-300">
+                          <div className="flex items-center space-x-3">
+                            <Image
+                              src={article.author.image}
+                              alt={article.author.name}
+                              quality={100}
+                              width={40}
+                              height={40}
+                              className="rounded-full"
+                            />
+                            <div className="flex flex-col w-40">
+                              <span className="font-bold">Written By</span>
+                              <div className="flex-none leading-tight opacity-90">
+                                {article.author.name}
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       )}
+                      <div className="flex flex-col w-40 text-sm">
+                        <span className="font-bold text-gray-700 dark:text-gray-300">
+                          Published
+                        </span>
+                        {article.publishedAt && (
+                          <div className="leading-tight text-gray-500 dark:text-gray-300 place-content-end opacity-90">
+                            <UpdatedAt
+                              date={friendlyTime(new Date(article.publishedAt))}
+                            />
+                          </div>
+                        )}
+                      </div>
                     </div>
-                  )}
-                </div>
+                  </div>
+                </Link>
               )
             })}
           </div>

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -37,7 +37,7 @@ const Blog: React.FC<React.PropsWithChildren<unknown>> = (allArticles: any) => {
                     key={fullSlug}
                     className="flex h-full flex-col justify-between rounded-lg border border-gray-100 px-5 py-8 dark:border-gray-800 md:px-8 hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-all ease-in-out"
                   >
-                    <h2 className="text-balance text-2xl font-bold">
+                    <h2 className="text-balance text-xl sm:text-2xl font-bold">
                       {article.title}
                     </h2>
 
@@ -46,7 +46,7 @@ const Blog: React.FC<React.PropsWithChildren<unknown>> = (allArticles: any) => {
                         {article.description}
                       </div>
                     )}
-                    <div className="relative z-10 flex w-full flex-col items-start justify-between space-y-10 pt-8 md:flex-row md:items-center md:space-y-0">
+                    <div className="relative z-10 flex sm:w-full flex-row items-center justify-between pt-8">
                       {article.author && (
                         <div className="flex w-full items-center gap-10 text-sm text-gray-700 dark:text-gray-300">
                           <div className="flex items-center space-x-3">
@@ -67,7 +67,7 @@ const Blog: React.FC<React.PropsWithChildren<unknown>> = (allArticles: any) => {
                           </div>
                         </div>
                       )}
-                      <div className="flex flex-col w-40 text-sm">
+                      <div className="flex flex-col w-40 text-sm m-0">
                         <span className="font-bold text-gray-700 dark:text-gray-300">
                           Published
                         </span>


### PR DESCRIPTION
> ai generated "cover" images on blog posts are worse than stock photos 
>
> low effort, adds nothing, maybe less than nothing, for the reader
>
>(stock photos are also shit)
> ~ [joel](https://x.com/jhooks/status/1799957589939130845)

![gif](https://media0.giphy.com/media/SAlO94T6Xjd7zu8RCx/giphy.gif?cid=1927fc1bwjv1s0al1eavteie3ebi8m3ntkzmmbu5i6s6v773&ep=v1_gifs_search&rid=giphy.gif&ct=g)

## index
![index desktop](https://github.com/skillrecordings/egghead-next/assets/6188161/5eaf783f-b3ac-4a7c-a1a8-21e323a000a9)
![index page mobile](https://github.com/skillrecordings/egghead-next/assets/6188161/2a87ba3f-4be9-4865-8fd2-7932929fbdd2)

## /[slug]
![article page desktop](https://github.com/skillrecordings/egghead-next/assets/6188161/643f1f79-3459-4834-b02c-6e5b2fce8ebf)
![article page mobile](https://github.com/skillrecordings/egghead-next/assets/6188161/ad6dd4c2-cc54-4c3c-852c-f3c3c970215a)