### PR TITLE
feat: switch typesense sorting to presets

### DIFF
--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -36,7 +36,9 @@ const tracer = getTracer('search-page')
 
 const createURL = (state: any) => `?${qs.stringify(state)}`
 
-const searchClient = typesenseInstantsearchAdapter().searchClient
+export const typesenseAdapter = typesenseInstantsearchAdapter()
+
+const searchClient = typesenseAdapter.searchClient
 
 const defaultProps = {
   searchClient,

--- a/src/server/routers/topics.ts
+++ b/src/server/routers/topics.ts
@@ -1,6 +1,9 @@
 import {router, baseProcedure} from '../trpc'
 import {z} from 'zod'
-import {typesenseInstantsearchAdapter} from '@/utils/typesense'
+import {
+  typesenseInstantsearchAdapter,
+  TYPESENSE_COLLECTION_NAME,
+} from '@/utils/typesense'
 
 const searchClient = typesenseInstantsearchAdapter().searchClient
 
@@ -14,7 +17,7 @@ export const topicRouter = router({
         .optional(),
     )
     .query(async ({input, ctx}) => {
-      const index = searchClient.initIndex('content_production')
+      const index = searchClient.initIndex(TYPESENSE_COLLECTION_NAME)
       // top 10 free playlists for a topic
       const filters = `access_state:free AND type:playlist ${
         input?.topic ? ` AND _tags:${input.topic}` : ''

--- a/src/utils/typesense.ts
+++ b/src/utils/typesense.ts
@@ -1,34 +1,29 @@
 import TypesenseInstantSearchAdapter from 'typesense-instantsearch-adapter'
 
+export const typsenseAdapterConfig = {
+  server: {
+    apiKey: process.env.NEXT_PUBLIC_TYPESENSE_API_KEY ?? '', // Be sure to use an API key that only allows search operations
+    nodes: [
+      {
+        host: process.env.NEXT_PUBLIC_TYPESENSE_HOST ?? 'test',
+        path: '',
+        port: Number(process.env.NEXT_PUBLIC_TYPESENSE_PORT) ?? 8108,
+        protocol: 'https',
+      },
+    ],
+
+    cacheSearchResultsForSeconds: 2 * 60,
+  },
+  // The following parameters are directly passed to Typesense's search API endpoint.
+  //  So you can pass any parameters supported by the search endpoint below.
+  //  query_by is required.
+  additionalSearchParameters: {
+    query_by: 'title,description,_tags,instructor_name,contributors',
+    preset: 'popular',
+  },
+}
+
 export const typesenseInstantsearchAdapter = () =>
-  new TypesenseInstantSearchAdapter({
-    server: {
-      apiKey: process.env.NEXT_PUBLIC_TYPESENSE_API_KEY ?? '', // Be sure to use an API key that only allows search operations
-      nodes: [
-        {
-          host: process.env.NEXT_PUBLIC_TYPESENSE_HOST ?? 'test',
-          path: '',
-          port: Number(process.env.NEXT_PUBLIC_TYPESENSE_PORT) ?? 8108,
-          protocol: 'https',
-        },
-      ],
-      cacheSearchResultsForSeconds: 2 * 60,
-    },
-    // The following parameters are directly passed to Typesense's search API endpoint.
-    //  So you can pass any parameters supported by the search endpoint below.
-    //  query_by is required.
-    additionalSearchParameters: {
-      query_by: 'title,description,_tags,instructor_name,contributors',
-    },
-  })
+  new TypesenseInstantSearchAdapter({...typsenseAdapterConfig})
 export const TYPESENSE_COLLECTION_NAME =
   process.env.NEXT_PUBLIC_TYPESENSE_COLLECTION_NAME || 'content_production'
-
-const BASE_SORT = `${TYPESENSE_COLLECTION_NAME}/sort/_eval([ (type:playlist):4, (type:lesson):3, (type:podcast):2], (type:talk):1):desc`
-
-export const SORT_PRESETS = {
-  POPULAR: `${BASE_SORT},search_research_sort:asc,rank:asc`,
-  RATING: `${BASE_SORT},average_rating_out_of_5:desc,rank:asc`,
-  CREATED_AT: `${BASE_SORT},published_at_timestamp:desc,rank:asc`,
-  MOST_WATCHED: `${BASE_SORT},watched_count:desc,rank:asc`,
-}


### PR DESCRIPTION
Since migrating to TypeSense, whenever a user inputs a search or clicks a filter the url is populated by the sorting that we need to do for the content that makes sense.

e.g. `https://egghead.io/q?q=react&sortBy=content_production/sort/_eval([%20(type:playlist):4,%20(type:lesson):3,%20(type:podcast):2],%20(type:talk):1):desc,search_research_sort:asc,rank:asc`

The first sorting function is particularly important as it rank sorts playlists to the top before other types of content. 

The other way to do this is with presets but @Creeland and I were having a rough time actually setting a preset apart from initial load. Turns out that the TypeSense adapter has an `updateConfiguration` function that we can call when we want to switch to a different preset as recommended [here](https://github.com/typesense/typesense-instantsearch-adapter/issues/195). 

I'm updating configuration in a select and calling instantsearches `refresh` to trigger another search. 

![gif](https://media2.giphy.com/media/Wa8fgr3p74wZdxANFM/giphy.gif?cid=1927fc1br3kxuj11zrui91fsq31q0h1p92vrquvptii0qaih&ep=v1_gifs_search&rid=giphy.gif&ct=g)