### PR TITLE
actually use the index for initial search state

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -299,8 +299,11 @@ const Search: FunctionComponent<React.PropsWithChildren<SearchProps>> = ({
           indexName={TYPESENSE_COLLECTION_NAME}
           searchClient={searchClient}
           onStateChange={onSearchStateChange}
+          future={{
+            preserveSharedStateOnUnmount: true,
+          }}
           initialUiState={{
-            TYPESENSE_COLLECTION_NAME: {
+            [TYPESENSE_COLLECTION_NAME]: {
               ...searchState,
             },
           }}


### PR DESCRIPTION
![gif ](https://media2.giphy.com/media/w0vFxYaCcvvJm/giphy.gif?cid=1927fc1bzvis3xxn0w88znn7pz3w3ct4qa8z58tstpo15avq&ep=v1_gifs_search&rid=giphy.gif&ct=g)