### PR TITLE
feat: add feature flag powered sales banner

### DIFF
--- a/src/components/app/header/index.tsx
+++ b/src/components/app/header/index.tsx
@@ -35,6 +35,7 @@ import {useClickAway} from 'react-use'
 import {ChevronDown} from 'lucide-react'
 import clsx from 'clsx'
 import {cn} from '@/ui/utils'
+import LifetimeSaleHeaderBanner from '@/components/cta/sale/lifetime-header-banner'
 
 type NavLinkProps = {
   name: string
@@ -367,6 +368,9 @@ const Header: FunctionComponent<React.PropsWithChildren<unknown>> = () => {
       {!viewer?.is_pro && !viewer?.is_instructor && pathname !== '/pricing' && (
         <SaleHeaderBanner />
       )}
+      {!viewer?.is_instructor &&
+        pathname !== '/pricing' &&
+        pathname !== '/forever' && <LifetimeSaleHeaderBanner />}
       <nav
         aria-label="header"
         className="relative h-12 text-sm border-b border-gray-200 dark:bg-gray-900 dark:border-gray-800 print:hidden dark:text-white text-gray-1000"

--- a/src/components/cta/sale/lifetime-header-banner.tsx
+++ b/src/components/cta/sale/lifetime-header-banner.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import Link from 'next/link'
+import analytics from '@/utils/analytics'
+
+import {getSaleBannerFeatureFlag} from '@/lib/feature-flags'
+import {usePathname} from 'next/navigation'
+
+const LifetimeSaleHeaderBanner = () => {
+  const [isSaleBannerEnabled, setIsSaleBannerEnabled] =
+    React.useState<boolean>(false)
+  const pathname = usePathname()
+
+  React.useEffect(() => {
+    getSaleBannerFeatureFlag('featureFlagLifetimeSale', 'saleBanner').then(
+      (result) => {
+        setIsSaleBannerEnabled(result ?? false)
+        console.log('isSaleBannerEnabled', result)
+      },
+    )
+  }, [])
+
+  return isSaleBannerEnabled ? (
+    <Link
+      href="/pricing"
+      onClick={() => {
+        analytics.events.activityInternalLinkClick(
+          'sale',
+          pathname ?? '',
+          'lifetime-sale-banner',
+        )
+      }}
+      className="group"
+    >
+      <div className="flex justify-center pl-2 text-xs text-white bg-gradient-to-r sm:px-2 sm:text-sm from-blue-500 to-indigo-500">
+        <div className="py-1 pr-3 leading-tight">
+          <span role="img" aria-hidden="true">
+            🌟
+          </span>{' '}
+          Sale: <span>Become a member for a lifetime</span>
+        </div>
+        <div className="flex items-center flex-shrink-0 px-2 py-px text-white bg-black dark:bg-white dark:bg-opacity-100 bg-opacity-20 dark:text-blue-600">
+          <span className="pr-1 font-medium">Become a Member</span>{' '}
+          <span role="img" aria-hidden="true">
+            →
+          </span>
+        </div>
+      </div>
+    </Link>
+  ) : null
+}
+
+export default LifetimeSaleHeaderBanner

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,16 +1,34 @@
 import {createClient} from '@vercel/edge-config'
 
 interface FeatureFlags {
-  allowedRoles: string[]
+  allowedRoles?: string[]
+  saleBanner?: string[]
 }
 
 // We use prefixes to avoid mixing up the flags with other Edge Config values
 const prefixKey = (prefix: string, key: string) => `${prefix}_${key}`
 
-export async function getDraftFeatureFlag(key: keyof FeatureFlags) {
-  const prefixedKey = prefixKey('featureFlagDraftCourse', key)
-  const edgeConfig = createClient(process.env.DRAFT_COURSE_EDGE_CONFIG)
+export async function getDraftFeatureFlag(
+  prefix: string,
+  key: keyof FeatureFlags,
+) {
+  if (!process.env.FEATURE_FLAGS_EDGE_CONFIG) return false
+  const prefixedKey = prefixKey(prefix, key)
+  const edgeConfig = createClient(process.env.FEATURE_FLAGS_EDGE_CONFIG)
   const featureFlag = await edgeConfig.get<FeatureFlags>(prefixedKey)
+
+  return featureFlag
+}
+
+export async function getSaleBannerFeatureFlag(
+  prefix: string,
+  key: keyof FeatureFlags,
+) {
+  if (!process.env.FEATURE_FLAGS_EDGE_CONFIG) return false
+  const prefixedKey = prefixKey(prefix, key)
+  const edgeConfig = createClient(process.env.FEATURE_FLAGS_EDGE_CONFIG)
+
+  const featureFlag = await edgeConfig.get<boolean>(prefixedKey)
 
   return featureFlag
 }

--- a/src/pages/instructor/index.tsx
+++ b/src/pages/instructor/index.tsx
@@ -57,7 +57,10 @@ Instructor.getLayout = function getLayout(Page: any, pageProps: any) {
 export const getServerSideProps: GetServerSideProps = async function ({req}) {
   const ability = await getAbilityFromToken(req.cookies[ACCESS_TOKEN_KEY])
   const roles = await loadCurrentViewerRoles(req.cookies[ACCESS_TOKEN_KEY])
-  const draftCourseRole = await getDraftFeatureFlag('allowedRoles')
+  const draftCourseRole = await getDraftFeatureFlag(
+    'featureFlagDraftCourse',
+    'allowedRoles',
+  )
 
   const canViewDraftCourses = roles?.includes(draftCourseRole)
 


### PR DESCRIPTION
This will check the `feature-flag` edge config store for the `featureFlagLifetimeSale_saleBanner` value and display the banner if that value is set to `true`

![image](https://github.com/user-attachments/assets/32a79b73-f925-4619-98df-2270f04d2ac7)


![gif](https://media3.giphy.com/media/26BRQTezZrKak4BeE/giphy.gif?cid=1927fc1burcaz740exg4rkjt3s9yd70f5vmcsfsvg9fw991o&ep=v1_gifs_search&rid=giphy.gif&ct=g)

![banner](https://github.com/user-attachments/assets/04577757-554e-4ffc-9d41-ca437716520b)
