### PR TITLE
fix: filter out unpublished lessons in lesson list

### DIFF
--- a/src/components/layouts/collection-page-layout.tsx
+++ b/src/components/layouts/collection-page-layout.tsx
@@ -874,8 +874,8 @@ const CollectionPageLayout: React.FunctionComponent<
               <div>
                 <ul>
                   {lessons.map((lesson: LessonResource, index: number) => {
+                    if (lesson?.published_at === null) return null
                     const tagImageUrl = `https://res.cloudinary.com/dg3gyk0gu/image/upload/w_72,h_72/v1683914713/tags/${lesson?.primary_tag?.name}.png`
-
                     const isComplete = completedLessonSlugs?.includes(
                       lesson.slug,
                     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type LessonResource = Resource & {
   thumb_url: string
   lesson_view_url: string
   id: string | number
+  published_at: string
   tags: any[]
   lessons: any[]
   primary_tag: any


### PR DESCRIPTION
As I was adding lessons for Johns course, I notice we don't do any sort of filter of unpublished lessons which will show up in the list and navigate you to home when you click on them.

![gif](https://media3.giphy.com/media/12c7MQi3q492Hm/giphy.gif?cid=1927fc1biqlsg5z3hf5o676lxa78tdgz4mod6u8775j0wjwd&ep=v1_gifs_search&rid=giphy.gif&ct=g)