### PR TITLE
fix: correctly set up ssr for /q

### DIFF
--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -58,7 +58,6 @@ const Search: FunctionComponent<React.PropsWithChildren<SearchProps>> = ({
   ...rest
 }) => {
   const [isFilterShown, setShowFilter] = useToggle(false)
-
   const noInstructorsSelected = (searchState: any) => {
     return get(searchState, 'refinementList.instructor_name', []).length === 0
   }
@@ -328,7 +327,7 @@ const Search: FunctionComponent<React.PropsWithChildren<SearchProps>> = ({
                     </div>
                   </div>
                   {!loading && (
-                    <NoSearchResults searchQuery={searchState.query} />
+                    <NoSearchResults searchQuery={searchState?.query ?? ''} />
                   )}
                   {loading && shouldDisplayLandingPageForTopics(topic) && (
                     <div className="flex py-8 justify-center">
@@ -365,7 +364,7 @@ const Search: FunctionComponent<React.PropsWithChildren<SearchProps>> = ({
                       </div>
                     )}
                   <ScrollElement name="hits" />
-                  <Stats searchQuery={searchState.query} />
+                  <Stats searchQuery={searchState?.query ?? ''} />
                   <h2 className="sm:px-5 px-3 mt-4 lg:text-2xl sm:text-xl text-lg dark:text-white font-semibold leading-tight">
                     Search Results
                   </h2>

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {useRouter} from 'next/router'
+import singletonRouter, {useRouter} from 'next/router'
 import Image from 'next/image'
 import Search from '@/components/search'
 import {NextSeo} from 'next-seo'
@@ -9,7 +9,6 @@ import {createUrl, parseUrl, titleFromPath} from '@/lib/search-url-builder'
 import {isEmpty, get, first} from 'lodash'
 import queryParamsPresent from '@/utils/query-params-present'
 import {loadInstructor} from '@/lib/instructors'
-import nameToSlug from '@/lib/name-to-slug'
 import getTracer from '@/utils/honeycomb-tracer'
 import {setupHttpTracing} from '@/utils/tracing-js/dist/src/'
 import Header from '@/components/app/header'
@@ -31,6 +30,7 @@ import {
   TYPESENSE_COLLECTION_NAME,
   typesenseInstantsearchAdapter,
 } from '@/utils/typesense'
+import nameToSlug from '@/lib/name-to-slug'
 
 const tracer = getTracer('search-page')
 
@@ -55,7 +55,7 @@ const getInstructorSlugFromInstructorList = (instructors: string[]) => {
 type SearchIndexProps = {
   error: string
   initialSearchState: any
-  resultsState: any
+  serverState: any
   pageTitle: string
   noIndexInitial: boolean
   initialInstructor: any
@@ -66,7 +66,7 @@ type SearchIndexProps = {
 const SearchIndex: any = ({
   error,
   initialSearchState,
-  resultsState,
+  serverState,
   pageTitle,
   noIndexInitial,
   initialInstructor,
@@ -77,8 +77,6 @@ const SearchIndex: any = ({
   const [instructor, setInstructor] = React.useState(initialInstructor)
   const [noIndex, setNoIndex] = React.useState(noIndexInitial)
   const debouncedState = React.useRef<any>()
-  const router = useRouter()
-
   const {loading, topicSanityData, topicGraphqlData} = useLoadTopicData(
     initialTopicGraphqlData,
     initialTopicSanityData,
@@ -121,7 +119,7 @@ const SearchIndex: any = ({
       const href: string = createUrl(searchState)
       setNoIndex(queryParamsPresent(href))
 
-      router.push(href, undefined, {
+      singletonRouter.push(href, undefined, {
         shallow: true,
       })
     }, 250)
@@ -132,9 +130,7 @@ const SearchIndex: any = ({
 
   const customProps = {
     searchState,
-    resultsState,
     createURL,
-    onSearchStateChange,
   }
 
   return (
@@ -142,20 +138,27 @@ const SearchIndex: any = ({
       <NextSeo
         noindex={noIndex}
         title={pageTitle}
-        canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${router.asPath}`}
+        canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${
+          typeof window !== 'undefined' ? window.location.pathname : '/q'
+        }`}
         openGraph={{
-          url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${router.asPath}`,
+          url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${
+            typeof window !== 'undefined' ? window.location.pathname : '/q'
+          }`,
           site_name: 'egghead',
         }}
       />
-      <Search
-        {...defaultProps}
-        {...customProps}
-        instructor={instructor}
-        topic={topicGraphqlData}
-        topicData={topicSanityData}
-        loading={loading}
-      />
+      <InstantSearchSSRProvider {...serverState}>
+        <Search
+          {...defaultProps}
+          {...customProps}
+          instructor={instructor}
+          topic={topicGraphqlData}
+          topicData={topicSanityData}
+          onSearchStateChange={onSearchStateChange}
+          loading={loading}
+        />
+      </InstantSearchSSRProvider>
     </div>
   )
 }
@@ -175,17 +178,6 @@ SearchIndex.getLayout = (Page: any, pageProps: any) => {
 
 export default SearchIndex
 
-function BrandPage({serverState}: any) {
-  return (
-    <InstantSearchSSRProvider {...serverState}>
-      <InstantSearch searchClient={searchClient} indexName="content_production">
-        <SearchBox />
-        <Hits />
-      </InstantSearch>
-    </InstantSearchSSRProvider>
-  )
-}
-
 export const getServerSideProps: GetServerSideProps = async function ({
   req,
   query,
@@ -200,9 +192,12 @@ export const getServerSideProps: GetServerSideProps = async function ({
   const initialSearchState = parseUrl(query)
   const pageTitle = titleFromPath(all as string[])
 
-  const serverState = await getServerState(<BrandPage />, {
-    renderToString,
-  })
+  const serverState = await getServerState(
+    <SearchIndex initialSearchState={initialSearchState} />,
+    {
+      renderToString,
+    },
+  )
 
   // Maps the InitialResults record to an array and gets the first (and only) result.
   // From there you have access to the state and result which matches what we expected before the upgrade to react-instantsearch v7
@@ -253,8 +248,8 @@ export const getServerSideProps: GetServerSideProps = async function ({
 
   return {
     props: {
-      resultsState: JSON.parse(JSON.stringify(resultsState)),
       initialSearchState,
+      serverState,
       pageTitle,
       noIndexInitial,
       initialInstructor,

--- a/src/pages/q/[[...all]].tsx
+++ b/src/pages/q/[[...all]].tsx
@@ -61,6 +61,7 @@ type SearchIndexProps = {
   initialInstructor: any
   initialTopicGraphqlData: any
   initialTopicSanityData: any
+  path: string
 }
 
 const SearchIndex: any = ({
@@ -72,6 +73,7 @@ const SearchIndex: any = ({
   initialInstructor,
   initialTopicGraphqlData,
   initialTopicSanityData,
+  path,
 }: SearchIndexProps) => {
   const [searchState, setSearchState] = React.useState(initialSearchState)
   const [instructor, setInstructor] = React.useState(initialInstructor)
@@ -138,13 +140,9 @@ const SearchIndex: any = ({
       <NextSeo
         noindex={noIndex}
         title={pageTitle}
-        canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${
-          typeof window !== 'undefined' ? window.location.pathname : '/q'
-        }`}
+        canonical={`${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`}
         openGraph={{
-          url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${
-            typeof window !== 'undefined' ? window.location.pathname : '/q'
-          }`,
+          url: `${process.env.NEXT_PUBLIC_DEPLOYMENT_URL}${path}`,
           site_name: 'egghead',
         }}
       />
@@ -191,6 +189,9 @@ export const getServerSideProps: GetServerSideProps = async function ({
 
   const initialSearchState = parseUrl(query)
   const pageTitle = titleFromPath(all as string[])
+  const path = req.url
+
+  console.log('mypath', path)
 
   const serverState = await getServerState(
     <SearchIndex initialSearchState={initialSearchState} />,
@@ -249,6 +250,7 @@ export const getServerSideProps: GetServerSideProps = async function ({
   return {
     props: {
       initialSearchState,
+      path,
       serverState,
       pageTitle,
       noIndexInitial,


### PR DESCRIPTION
We were never actually using `InstantSearchSSRProvider` correctly. It looks like there was a separate `BrandPage` component that had the SSR provider wrapped that seems like it was from some example code. This wraps our `Search` Component in the provider so the server will pass results to the client

https://www.loom.com/share/1a315170ae874435814045ff2606040a?sid=54199555-e00e-4081-99d5-8a8eb32e08be


![gif](![g cat jump](https://media1.giphy.com/media/Wu7UDoOBHPHm8/giphy.gif?cid=1927fc1bojft0slr1xjiz9y4q5umn17fiadnyq2v00tlmz62&ep=v1_gifs_search&rid=giphy.gif&ct=g))