### PR TITLE
feat: pass video metadata to mux

### DIFF
--- a/src/pages/[post].tsx
+++ b/src/pages/[post].tsx
@@ -565,6 +565,12 @@ function PostPlayer({
   return (
     <MuxPlayer
       {...playerProps}
+      metadata={{
+        video_id: post.id,
+        video_title: post.fields.title,
+        view_user_id: viewer?.id,
+        video_category: post.fields.primaryTagId,
+      }}
       playbackId={playbackId}
       onEnded={() => {
         if (eggheadLessonId) {


### PR DESCRIPTION
This adds video metadata for mux so we have more info when viewing analytics.

https://www.mux.com/blog/mux-flavored-html-video-tag#and-i-get-data-too

![gif](https://media4.giphy.com/media/l4RKhOL0xiBdbgglFi/giphy.gif?cid=1927fc1blihxxr0dkcbzqeszhx16gyjgkeusmpoq6ho8btau&ep=v1_gifs_search&rid=giphy.gif&ct=g)