### PR TITLE
feat: Post completion overlay

### DIFF
--- a/src/components/posts/video-player-overlay.tsx
+++ b/src/components/posts/video-player-overlay.tsx
@@ -112,11 +112,11 @@ function CursorCTAOverlay({
                 height={80}
                 className="hidden sm:block"
               />
-              <h2 className="text-md sm:text-2xl font-bold sm:mb-4">
-                Reliably Build Software with AI through Cursor
+              <h2 className="text-md sm:text-2xl font-bold sm:mb-4 text-balance">
+                Take Cursor to the Next Level with Live Training
               </h2>
             </div>
-            <p className="text-center mb-2 sm:mb-6 text-muted-foreground">
+            <p className="text-center mb-2 sm:mb-6 text-muted-foreground text-balance">
               John Lindquist is teaching a workshop on how to use Cursor to it's
               fullest abilities. Get notified when the workshop is released.
             </p>

--- a/src/components/posts/video-player-overlay.tsx
+++ b/src/components/posts/video-player-overlay.tsx
@@ -1,0 +1,144 @@
+import Link from 'next/link'
+import Image from 'next/image'
+
+import {
+  useVideoPlayerOverlay,
+  type CompletedAction,
+} from '@/hooks/mux/use-video-player-overlay'
+import {Post} from '@/pages/[post]'
+import Spinner from '@/spinner'
+import {Button} from '@/ui/button'
+import {ArrowRight} from 'lucide-react'
+import {RefreshCw} from 'lucide-react'
+import {Card, CardContent, CardTitle, CardHeader, CardFooter} from '@/ui/card'
+import {motion} from 'framer-motion'
+
+type VideoPlayerOverlayProps = {
+  resource: Post
+}
+
+const VideoPlayerOverlay: React.FC<VideoPlayerOverlayProps> = ({resource}) => {
+  const {state: overlayState, dispatch} = useVideoPlayerOverlay()
+
+  switch (overlayState.action?.type) {
+    case 'COMPLETED':
+      const {playerRef, cta} = overlayState.action as CompletedAction
+
+      if (cta === 'cursor_workshop') {
+        return (
+          <motion.div
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
+            exit={{opacity: 0}}
+            aria-live="polite"
+            className="z-40 bg-background/85 absolute left-0 top-0 flex h-full w-full flex-col items-center justify-center pb-6 backdrop-blur-md sm:pb-16 text-white"
+          >
+            <CursorCTAOverlay
+              signUpLink="/workshop/cursor"
+              onReplay={() => {
+                if (playerRef.current) {
+                  playerRef.current.play()
+                }
+                dispatch({type: 'HIDDEN'})
+              }}
+            />
+          </motion.div>
+        )
+      }
+
+      return (
+        <motion.div
+          initial={{opacity: 0}}
+          animate={{opacity: 1}}
+          exit={{opacity: 0}}
+          aria-live="polite"
+          className="z-40 bg-background/85 absolute left-0 top-0 flex h-full w-full flex-col items-center justify-center pb-6 backdrop-blur-md sm:pb-16 text-white"
+        >
+          <div className="flex flex-col items-center justify-center gap-2 p-4">
+            <h2 className="text-lg sm:text-2xl font-bold mb-4 text-center">
+              {resource.fields.title}
+            </h2>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (playerRef.current) {
+                  playerRef.current.play()
+                }
+                dispatch({type: 'HIDDEN'})
+              }}
+              className="border border-blue-600 hover:bg-blue-600"
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Watch again
+            </Button>
+          </div>
+        </motion.div>
+      )
+    case 'LOADING':
+      return (
+        <div
+          aria-live="polite"
+          className="text-foreground absolute left-0 top-0 z-40 flex aspect-video h-full w-full flex-col items-center justify-center gap-10 bg-black/80 p-5 text-lg backdrop-blur-md"
+        >
+          <Spinner className="text-white" />
+        </div>
+      )
+    case 'HIDDEN':
+      return null
+    default:
+      return null
+  }
+}
+
+export default VideoPlayerOverlay
+
+function CursorCTAOverlay({
+  signUpLink,
+  onReplay,
+}: {
+  signUpLink: string
+  onReplay: () => void
+}) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 p-4">
+      <Card className="w-full max-w-2xl border-none">
+        <CardContent className="text-center p-0 sm:p-6">
+          <div className="sm:px-8 flex flex-col items-center justify-center">
+            <div className="flex flex-col items-center gap-2">
+              <Image
+                src="https://d2eip9sf3oo6c2.cloudfront.net/tags/images/000/001/411/full/cursor.png"
+                alt="Cursor"
+                width={80}
+                height={80}
+                className="hidden sm:block"
+              />
+              <h2 className="text-md sm:text-2xl font-bold sm:mb-4">
+                Reliably Build Software with AI through Cursor
+              </h2>
+            </div>
+            <p className="text-center mb-2 sm:mb-6 text-muted-foreground">
+              John Lindquist is teaching a workshop on how to use Cursor to it's
+              fullest abilities. Get notified when the workshop is released.
+            </p>
+          </div>
+        </CardContent>
+        <CardFooter className="flex gap-2 items-center justify-center p-0">
+          <Button
+            variant="outline"
+            onClick={onReplay}
+            className="border border-blue-600 hover:bg-blue-600"
+          >
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Watch again
+          </Button>
+          <Link href={signUpLink} className="">
+            <Button className="w-full max-w-xs bg-blue-500 hover:bg-blue-600">
+              Join Waitlist
+              <ArrowRight className="ml-2 h-5 w-5" />
+            </Button>
+          </Link>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/posts/video-player-overlay.tsx
+++ b/src/components/posts/video-player-overlay.tsx
@@ -122,7 +122,13 @@ function CursorCTAOverlay({
             </p>
           </div>
         </CardContent>
-        <CardFooter className="flex gap-2 items-center justify-center p-0">
+        <CardFooter className="flex flex-row-reverse sm:flex-col gap-2 sm:gap-4 items-center justify-center p-0">
+          <Link href={signUpLink} className="">
+            <Button className="w-full max-w-xs bg-blue-500 hover:bg-blue-600">
+              Join Waitlist
+              <ArrowRight className="ml-2 h-5 w-5" />
+            </Button>
+          </Link>
           <Button
             variant="outline"
             onClick={onReplay}
@@ -131,12 +137,6 @@ function CursorCTAOverlay({
             <RefreshCw className="mr-2 h-4 w-4" />
             Watch again
           </Button>
-          <Link href={signUpLink} className="">
-            <Button className="w-full max-w-xs bg-blue-500 hover:bg-blue-600">
-              Join Waitlist
-              <ArrowRight className="ml-2 h-5 w-5" />
-            </Button>
-          </Link>
         </CardFooter>
       </Card>
     </div>

--- a/src/hooks/mux/use-video-player-overlay.tsx
+++ b/src/hooks/mux/use-video-player-overlay.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import React, {createContext, Reducer, useContext, useReducer} from 'react'
+import type {MuxPlayerRefAttributes} from '@mux/mux-player-react'
+
+type VideoPlayerOverlayState = {
+  action: VideoPlayerOverlayAction | null
+}
+
+export type CompletedAction = {
+  type: 'COMPLETED'
+  playerRef: React.RefObject<MuxPlayerRefAttributes | null>
+  cta?: string
+}
+
+export type VideoPlayerOverlayAction =
+  | CompletedAction
+  | {type: 'BLOCKED'}
+  | {type: 'HIDDEN'}
+  | {type: 'LOADING'}
+
+const initialState: VideoPlayerOverlayState = {
+  action: {
+    type: 'HIDDEN',
+  },
+}
+
+const reducer: Reducer<VideoPlayerOverlayState, VideoPlayerOverlayAction> = (
+  state,
+  action,
+) => {
+  switch (action.type) {
+    case 'COMPLETED':
+      // TODO: Track video completion
+      return {
+        ...state,
+        action,
+      }
+    case 'LOADING':
+      console.log('loading')
+      return {
+        ...state,
+        action,
+      }
+    case 'BLOCKED':
+      return {
+        ...state,
+        action,
+      }
+    case 'HIDDEN': {
+      return {
+        ...state,
+        action,
+      }
+    }
+    default:
+      return state
+  }
+}
+
+type VideoPlayerOverlayContextType = {
+  state: VideoPlayerOverlayState
+  dispatch: React.Dispatch<VideoPlayerOverlayAction>
+}
+
+export const VideoPlayerOverlayProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const value = React.useMemo(() => ({state, dispatch}), [state, dispatch])
+
+  return (
+    <VideoPlayerOverlayContext.Provider value={value}>
+      {children}
+    </VideoPlayerOverlayContext.Provider>
+  )
+}
+
+const VideoPlayerOverlayContext = createContext<
+  VideoPlayerOverlayContextType | undefined
+>(undefined)
+
+export const useVideoPlayerOverlay = () => {
+  const context = useContext(VideoPlayerOverlayContext)
+  if (!context) {
+    throw new Error(
+      'useVideoPlayerContext must be used within a VideoPlayerProvider',
+    )
+  }
+  return {
+    state: context.state,
+    dispatch: context.dispatch,
+  }
+}

--- a/src/hooks/use-mux-player.tsx
+++ b/src/hooks/use-mux-player.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import React, {createContext, useContext} from 'react'
+import type {MuxPlayerRefAttributes} from '@mux/mux-player-react'
+
+type MuxPlayerContextType = {
+  setMuxPlayerRef: React.Dispatch<
+    React.SetStateAction<React.RefObject<MuxPlayerRefAttributes | null> | null>
+  >
+  muxPlayerRef: React.RefObject<MuxPlayerRefAttributes | null> | null
+}
+
+export const MuxPlayerProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const [muxPlayerRef, setMuxPlayerRef] =
+    React.useState<React.RefObject<MuxPlayerRefAttributes | null> | null>(null)
+
+  return (
+    <MuxPlayerContext.Provider value={{muxPlayerRef, setMuxPlayerRef}}>
+      {children}
+    </MuxPlayerContext.Provider>
+  )
+}
+
+const MuxPlayerContext = createContext<MuxPlayerContextType | undefined>(
+  undefined,
+)
+
+export const useMuxPlayer = () => {
+  const context = useContext(MuxPlayerContext)
+  if (!context) {
+    throw new Error('useMuxPlayer must be used within a MuxPlayerProvider')
+  }
+  return context
+}

--- a/src/pages/[post].tsx
+++ b/src/pages/[post].tsx
@@ -185,9 +185,7 @@ type MuxTimeUpdateEvent = {
 }
 
 async function getPost(slug: string) {
-  console.log('Getting post for slug:', slug)
   const {hashFromSlug, originalSlug} = parseSlugForHash(slug)
-  console.log('Parsed slug:', {hashFromSlug, originalSlug})
 
   const conn = await mysql.createConnection(access)
 
@@ -205,7 +203,6 @@ async function getPost(slug: string) {
     `,
       [slug, slug, `%${hashFromSlug}`, `%${hashFromSlug}`],
     )
-    console.log('Video resource rows:', videoResourceRows)
 
     // Get post data with proper type checking
     const [postRows] = await conn.execute<RowDataPacket[]>(

--- a/src/pages/[post].tsx
+++ b/src/pages/[post].tsx
@@ -257,8 +257,6 @@ async function getPost(slug: string) {
     )
     const tags = tagRows
 
-    console.log('tags', tags)
-
     return {
       videoResource,
       post: postData.data,

--- a/src/pages/[post].tsx
+++ b/src/pages/[post].tsx
@@ -263,55 +263,6 @@ export const getStaticProps: GetServerSideProps = async function ({params}) {
     `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/lessons/${post.fields.eggheadLessonId}`,
   ).then((res) => res.json())
 
-  const resource = {
-    id: `${post.fields.eggheadLessonId}`,
-    externalId: post.id,
-    title: post.fields.title,
-    slug: post.fields.slug,
-    summary: post.fields.description,
-    description: post.fields.body,
-    name: post.fields.title,
-    path: `/${post.fields.slug}`,
-    type: post.fields.postType,
-    ...(lesson && {
-      instructor_name: lesson.instructor?.full_name,
-      instructor: lesson.instructor,
-      image: lesson.image_480_url,
-    }),
-  }
-
-  let client = new Typesense.Client({
-    nodes: [
-      {
-        host: process.env.NEXT_PUBLIC_TYPESENSE_HOST!,
-        port: 443,
-        protocol: 'https',
-      },
-    ],
-    apiKey: process.env.TYPESENSE_WRITE_API_KEY!,
-    connectionTimeoutSeconds: 2,
-  })
-
-  if (
-    post.fields.state === 'published' &&
-    post.fields.visibility === 'public'
-  ) {
-    await client
-      .collections(process.env.TYPESENSE_COLLECTION_NAME!)
-      .documents()
-      .upsert({
-        ...resource,
-        published_at_timestamp: post.updatedAt.getTime(),
-      })
-      .catch((err) => {})
-  } else {
-    await client
-      .collections(process.env.TYPESENSE_COLLECTION_NAME!)
-      .documents()
-      .delete(resource.id)
-      .catch((err) => {})
-  }
-
   const mdxSource = await serializeMDX(post.fields?.body ?? '', {
     useShikiTwoslash: true,
     syntaxHighlighterOptions: {
@@ -319,25 +270,6 @@ export const getStaticProps: GetServerSideProps = async function ({params}) {
       endpoint: process.env.SHIKI_ENDPOINT!,
     },
   })
-
-  // const mdxSource = await serialize(post.fields.body, {
-  //   mdxOptions: {
-  //     remarkPlugins: [
-  //       require(`remark-slug`),
-  //       require(`remark-footnotes`),
-  //       require(`remark-code-titles`),
-  //     ],
-  //     rehypePlugins: [
-  //       [
-  //         require(`rehype-shiki`),
-  //         {
-  //           theme: `./src/styles/material-theme-dark.json`,
-  //           useBackground: false,
-  //         },
-  //       ],
-  //     ],
-  //   },
-  // })
 
   return {
     props: {

--- a/src/pages/[post].tsx
+++ b/src/pages/[post].tsx
@@ -310,7 +310,7 @@ export const getStaticProps: GetServerSideProps = async function ({params}) {
         }),
       },
       videoResource: convertToSerializeForNextResponse(videoResource),
-      tags || [],
+      tags: tags || [],
     },
     revalidate: 60,
   }


### PR DESCRIPTION
This adds completion overlay to posts so we can CTA Johns workshop on cursor lessons.

## Cursor CTA
![desktop](https://github.com/user-attachments/assets/7ea8d77c-09bf-4b12-baf0-135ba52b29ec)

Mobile is a little crowded but it looks ok:
![mobile](https://github.com/user-attachments/assets/d28b38cb-e427-4ce7-b569-223ec25b8752)

## Default
![default desktop](https://github.com/user-attachments/assets/d3f90963-4cfa-4b38-8cfe-61edcd68fecf)


![gif](https://media0.giphy.com/media/ANWIS2HYfROI8/giphy.gif?cid=1927fc1bw779p4bdweyfptocs5w6c72g6icuje3z7cyye3t7&ep=v1_gifs_search&rid=giphy.gif&ct=g)