### PR TITLE
feat: hide course lessons in TheFeed

### DIFF
--- a/src/components/pages/home/the-feed.tsx
+++ b/src/components/pages/home/the-feed.tsx
@@ -8,7 +8,14 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import Pagination from '@/components/search/pagination'
 import PresetOptions from '@/components/search/components/preset-options'
 import {usePagination} from 'react-instantsearch'
+import {typsenseAdapterConfig} from '@/utils/typesense'
 
+typesenseAdapter.updateConfiguration({
+  ...typsenseAdapterConfig,
+  additionalSearchParameters: {
+    preset: 'the_feed',
+  },
+})
 const searchClient = typesenseAdapter.searchClient
 const queryClient = new QueryClient()
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,8 @@ import groq from 'groq'
 import {getServerState} from 'react-instantsearch'
 import {renderToString} from 'react-dom/server'
 import TheFeed from '@/components/pages/home/the-feed'
+import {typsenseAdapterConfig} from '@/utils/typesense'
+import {typesenseAdapter} from './q/[[...all]]'
 
 const HomePage: FunctionComponent<React.PropsWithChildren<any>> = ({
   data,
@@ -86,6 +88,13 @@ const homepageQuery = groq`*[_type == 'resource' && slug.current == "curated-hom
 
 export async function getStaticProps() {
   const data = await sanityClient.fetch(homepageQuery)
+
+  typesenseAdapter.updateConfiguration({
+    ...typsenseAdapterConfig,
+    additionalSearchParameters: {
+      preset: 'the_feed',
+    },
+  })
 
   const searchServerState = await getServerState(<TheFeed />, {
     renderToString,


### PR DESCRIPTION

![Expert led courses for front-end web developers   egghead io](https://github.com/user-attachments/assets/af536c0b-da7e-4257-a099-49f4cc669e8a)


this uses a new preset `the_feed` which currently sorts and items that have `belongs_to_course:true` to the bottom


![gif](https://media2.giphy.com/media/7zoOcZshec8nqdFKeG/giphy.gif?cid=1927fc1bg1etd2g2jut2me6uf9dasodnjtamrjst2gzslj7f&ep=v1_gifs_search&rid=giphy.gif&ct=g)