### PR TITLE
feat: refactor ActiveSale and Hero components to use date and time prop

### DIFF
--- a/src/components/workshop/cursor/Hero.tsx
+++ b/src/components/workshop/cursor/Hero.tsx
@@ -4,10 +4,9 @@ import {motion} from 'framer-motion'
 import {fadeInUp, scaleIn} from './animations'
 import {useState, useEffect} from 'react'
 import './styles.css'
-import {ArrowCircleDownIcon} from '@heroicons/react/solid'
 import Image from 'next/image'
 import {Button} from '@/ui'
-import {Calendar, Clock, MapPin} from 'lucide-react'
+import TimeAndLocation from './time-and-location'
 
 export interface SignUpFormRef {
   focus: () => void
@@ -46,9 +45,13 @@ function scrollToSignup(
 interface HeroProps {
   formRef: React.RefObject<SignUpFormRef>
   saleisActive: boolean
+  dateAndTime: {
+    date: string
+    time: string
+  }
 }
 
-export default function Hero({formRef, saleisActive}: HeroProps) {
+export default function Hero({formRef, saleisActive, dateAndTime}: HeroProps) {
   const [phraseIndex, setPhraseIndex] = useState(0)
 
   useEffect(() => {
@@ -121,19 +124,13 @@ export default function Hero({formRef, saleisActive}: HeroProps) {
         >
           <div className="mt-12 flex flex-col gap-4 justify-center items-center">
             {saleisActive && (
-              <div className="flex flex-col gap-2 text-sm text-muted-foreground md:flex-row md:gap-6">
-                <div className="flex items-center gap-1 ">
-                  <Calendar className="h-6 w-6" />
-                  <span className="text-lg">March 20, 2025</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <Clock className="h-6 w-6" />
-                  <span className="text-lg">9:00 AM - 2:00 PM (PDT)</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <MapPin className="h-6 w-6" />
-                  <span className="text-lg">Zoom</span>
-                </div>
+              <div className="">
+                <TimeAndLocation
+                  date={dateAndTime.date}
+                  time={dateAndTime.time}
+                  iconSize={6}
+                  className="text-lg gap-2 text-muted-foreground flex md:flex-row md:gap-6"
+                />
               </div>
             )}
             <Button

--- a/src/components/workshop/cursor/active-sale.tsx
+++ b/src/components/workshop/cursor/active-sale.tsx
@@ -1,7 +1,6 @@
-import {Button} from '@/ui/button'
-import {Calendar, Clock, MapPin, AsteriskIcon} from 'lucide-react'
+import {AsteriskIcon} from 'lucide-react'
 import Link from 'next/link'
-
+import TimeAndLocation from './time-and-location'
 const CheckIcon = () => {
   return (
     <svg
@@ -24,9 +23,14 @@ const CheckIcon = () => {
 const ActiveSale = ({
   isPro,
   workshopFeatures,
+  dateAndTime,
 }: {
   isPro: boolean
   workshopFeatures: string[]
+  dateAndTime: {
+    date: string
+    time: string
+  }
 }) => {
   const paymentLink = `${
     process.env.NEXT_PUBLIC_LIVE_WORKSHOP_STRIPE_PAYMENT_LINK
@@ -83,7 +87,10 @@ const ActiveSale = ({
                   )}
                 </div>
               </div>
-              <TimeAndLocation />
+              <TimeAndLocation
+                date={dateAndTime.date}
+                time={dateAndTime.time}
+              />
               <div className="p-6 pt-0 grid gap-4">
                 <ul className="flex flex-col gap-2 w-fit mx-auto text-md">
                   {workshopFeatures.map((feature) => (
@@ -120,25 +127,6 @@ const ActiveSale = ({
           </div>
         </div>
       </section>
-    </div>
-  )
-}
-
-const TimeAndLocation = () => {
-  return (
-    <div className="px-6 pb-4 flex flex-col  text-md text-muted-foreground  md:gap-2 opacity-80 items-center justify-center">
-      <div className="flex items-center gap-1">
-        <Calendar className="h-5 w-5" />
-        <span>March 20, 2025</span>
-      </div>
-      <div className="flex items-center gap-1">
-        <Clock className="h-5 w-5" />
-        <span>9:00 AM - 2:00 PM (PDT)</span>
-      </div>
-      <div className="flex items-center gap-1">
-        <MapPin className="h-5 w-5" />
-        <span>Zoom</span>
-      </div>
     </div>
   )
 }

--- a/src/components/workshop/cursor/time-and-location.tsx
+++ b/src/components/workshop/cursor/time-and-location.tsx
@@ -1,0 +1,44 @@
+import {Calendar, Clock, MapPin} from 'lucide-react'
+import {cn} from '@/ui/utils'
+
+const TimeAndLocation = ({
+  date,
+  time,
+  className,
+  iconSize,
+}: {
+  date: string
+  time: string
+  className?: string
+  iconSize?: number
+}) => {
+  return (
+    <div
+      className={cn(
+        'px-6 pb-4 flex flex-col  text-md text-muted-foreground  md:gap-2 opacity-80 items-center justify-center',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-1">
+        <Calendar
+          className={cn('h-5 w-5', iconSize && `h-${iconSize} w-${iconSize}`)}
+        />
+        <span>{date}</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <Clock
+          className={cn('h-5 w-5', iconSize && `h-${iconSize} w-${iconSize}`)}
+        />
+        <span>{time}</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <MapPin
+          className={cn('h-5 w-5', iconSize && `h-${iconSize} w-${iconSize}`)}
+        />
+        <span>Zoom</span>
+      </div>
+    </div>
+  )
+}
+
+export default TimeAndLocation

--- a/src/pages/workshop/cursor/index.tsx
+++ b/src/pages/workshop/cursor/index.tsx
@@ -2,11 +2,10 @@
 import Layout from '@/components/app/layout'
 import Hero from '@/components/workshop/cursor/Hero'
 import Features from '@/components/workshop/cursor/Features'
-import WorkshopStructure from '@/components/workshop/cursor/WorkshopStructure'
 import Instructor from '@/components/workshop/cursor/Instructor'
 import SignUpForm from '@/components/workshop/cursor/SignUpForm'
 import type {SignUpFormRef} from '@/components/workshop/cursor/Hero'
-import type {GetServerSideProps, NextPage} from 'next'
+import type {GetServerSideProps} from 'next'
 import {useRef} from 'react'
 import {NextSeo} from 'next-seo'
 import {getLastChargeForActiveSubscription} from '@/lib/subscriptions'
@@ -14,7 +13,6 @@ import ActiveSale from '@/components/workshop/cursor/active-sale'
 
 import CtaSection from '@/components/workshop/cursor/cta-section'
 import {useViewer} from '@/context/viewer-context'
-import {Scale} from 'lucide-react'
 
 const WorkshopPage = () => {
   const formRef = useRef<SignUpFormRef>(null)
@@ -32,11 +30,20 @@ const WorkshopPage = () => {
     'Hour long break for lunch',
   ]
 
+  const dateAndTime = {
+    date: 'March 27, 2025',
+    time: '9:00 AM - 2:00 PM (PDT)',
+  }
+
   return (
     <main className="min-h-screen relative bg-white dark:bg-gray-900">
       <div className="relative">
         <div className="relative">
-          <Hero formRef={formRef} saleisActive={saleisActive} />
+          <Hero
+            formRef={formRef}
+            saleisActive={saleisActive}
+            dateAndTime={dateAndTime}
+          />
           <Features />
         </div>
         {/* <WorkshopStructure /> */}
@@ -49,6 +56,7 @@ const WorkshopPage = () => {
             <ActiveSale
               isPro={isPro}
               workshopFeatures={LIVE_WORKSHOP_FEATURES}
+              dateAndTime={dateAndTime}
             />
           }
         />


### PR DESCRIPTION
This updates the cursor workshop date to next thursday (03/27) in prep for updating the landing page. It centralizes date to a single location so we don't have to copy/paste in multiple files.

We'll want to perform following todos and merge this an hour before the workshop starts tomorrow (03/20)

## TODO
- [x] Create product, payment link, and promo code in stripe
- [x] Update `NEXT_PUBLIC_LIVE_WORKSHOP_STRIPE_PAYMENT_LINK`
- [x] Update `NEXT_PUBLIC_LIVE_WORKSHOP_PROMO_CODE`
- [x] Update `WORKSHOP_PRODUCT_ID`

![g workshop](https://media0.giphy.com/media/29bbyQvQskgkdt2Pa6/giphy.gif?cid=1927fc1bb2sj0zgefngkm2y8a2jmxtplk0pktcbispwsqmnw&ep=v1_gifs_search&rid=giphy.gif&ct=g)