### PR TITLE
feat: implement workshop parity coupon functionality in ActiveSale workshop component

### DIFF
--- a/src/components/workshop/cursor/parity-coupon-message.tsx
+++ b/src/components/workshop/cursor/parity-coupon-message.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import {ParityCouponMessageProps} from '@/types'
+
+const WorkshopParityCouponMessage = ({
+  coupon,
+  countryName,
+  onApply,
+  onDismiss,
+  isPPP,
+  reduced,
+}: ParityCouponMessageProps & {reduced?: boolean}) => {
+  const percentOff = coupon && Math.round(coupon.coupon_discount * 100)
+  const [showFlag, setShowFlag] = React.useState<boolean>(false)
+
+  return (
+    <div className="max-w-screen-lg p-8 m-5 mx-auto text-left bg-white border border-gray-200 rounded-lg shadow-lg dark:bg-gray-800 dark:border-gray-800">
+      <h2 className="text-base">
+        It looks like you're in{' '}
+        <img
+          loading="lazy"
+          width={showFlag ? 18 : 0}
+          onLoad={() => setShowFlag(true)}
+          alt={coupon.coupon_region_restricted_to}
+          className={`inline-block ${showFlag ? 'mr-1' : ''}`}
+          src={`https://hardcore-golick-433858.netlify.app/image?code=${coupon.coupon_region_restricted_to}`}
+        />
+        {countryName}. 👋 To support global learning, we'd like to offer you a
+        discount of <strong>{percentOff}%</strong> to account for differences in
+        currencies.
+      </h2>
+      <p className="inline-block mt-5 text-base">
+        If that sounds good, you can apply the discount below before continuing.
+      </p>
+      <div className="flex flex-col items-center mt-4">
+        <label
+          className={`inline-flex items-center px-4 py-3 rounded-md  transition-all ease-in-out duration-150 cursor-pointer border hover:bg-gray-100 dark:hover:bg-gray-700 border-opacity-40 ${
+            isPPP ? 'border-blue-500' : ' border-gray-300'
+          }`}
+        >
+          <input
+            className="form-checkbox"
+            name="isPPPActivated"
+            type="checkbox"
+            checked={isPPP}
+            onChange={isPPP ? onDismiss : onApply}
+          />
+          <span className="ml-4 font-semibold leading-4">
+            {isPPP
+              ? `Activated ${percentOff}% off with regional pricing`
+              : `Activate ${percentOff}% off with regional pricing`}
+          </span>
+        </label>
+      </div>
+      {reduced && (
+        <p className="mt-4 text-sm text-gray-600">
+          *The discount is not valid in conjunction with other promotions.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default WorkshopParityCouponMessage


### PR DESCRIPTION
This uses the `useCommerceMachine` hook to grab any available PPP coupons then manages its own state to apply the coupon if the user selects the PPP checkbox

- Added a custom hook `useWorkshopCoupon` to manage coupon application logic.
- Introduced `WorkshopParityCouponMessage` component to display discount information based on user location.
- Updated `ActiveSale` component to utilize the new hook and conditionally render the coupon message.

![ppp dialog shown](https://github.com/user-attachments/assets/ff6d78e8-1750-40ad-8e95-25e9c05ceb45)


![gif](https://media3.giphy.com/media/3Zs26J8u7LWdW/giphy.gif?cid=1927fc1bk1foo874ulu97g6p1ah0r4knl91irm7xrmju6i8l&ep=v1_gifs_search&rid=giphy.gif&ct=g)