### PR TITLE
feat: update Claude Code workshop copy to 'Transform into a Claude Code Power User'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "cSpell.words": ["badass", "eggheadio"]
+  "cSpell.words": ["badass", "eggheadio"],
+  "search.searchEditor.defaultNumberOfContextLines": 10
 }

--- a/src/components/workshop/claude-code/Hero.tsx
+++ b/src/components/workshop/claude-code/Hero.tsx
@@ -193,7 +193,7 @@ export default function Hero({formRef, saleisActive, workshop}: HeroProps) {
           {...fadeInUp}
           className="lg:text-5xl sm:text-4xl text-xl flex flex-col relative mb-6 font-extrabold tracking-tight dark:text-white leading-tight"
         >
-          Build Production-Grade Apps with Claude Code
+          Transform into a Claude Code Power User
         </motion.h1>
 
         <motion.p

--- a/src/components/workshop/claude-code/active-sale.tsx
+++ b/src/components/workshop/claude-code/active-sale.tsx
@@ -176,13 +176,13 @@ const ActiveSale = ({
               Chosen by 150+ Developers Who Improved their AI Dev Workflows
             </h3>
             <p className="mb-8 text-center text-lg opacity-80 mx-auto">
-              This workshop is for developers and engineers who are ready to move
-              beyond the hype and build real, reliable, and robust systems with
-              AI. If you're comfortable with TypeScript and want to become the
-              AI architect your team needs, this is for you.
+              This workshop is for developers and engineers who are ready to
+              move beyond the hype and build real, reliable, and robust systems
+              with AI. If you're comfortable with TypeScript and want to become
+              the AI architect your team needs, this is for you.
               <br />
               <br />
-              Your path to building production-grade systems with AI starts here.
+              Your transformation into a Claude Code power user starts here.
             </p>
           </div>
           {teamToggleState ? (
@@ -376,7 +376,7 @@ function SinglePurchaseUI({
         <div className="bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-800 rounded-lg text-card-foreground shadow-sm">
           <div className="flex flex-col pt-6 pb-4 px-6 space-y-2 text-center">
             <h3 className="text-2xl font-bold text-balance">
-              Build Production-Grade Systems with Claude Code
+              Transform into a Claude Code Power User
             </h3>
             <Price
               isLiveWorkshopLoading={isLiveWorkshopLoading}

--- a/src/components/workshop/claude-code/contact-form.tsx
+++ b/src/components/workshop/claude-code/contact-form.tsx
@@ -72,7 +72,7 @@ export function ContactForm({
   return (
     <div className={cn('max-w-lg sm:mx-auto mx-4', className)}>
       <h3 className="text-2xl font-bold text-center mt-4">
-        Build Production-Grade Systems with Claude Code
+        Transform into a Claude Code Power User
       </h3>
       {teamWorkshopFeatures && (
         <div className="mb-6">

--- a/src/pages/workshop/claude-code/index.tsx
+++ b/src/pages/workshop/claude-code/index.tsx
@@ -248,7 +248,7 @@ WorkshopPage.getLayout = (Page: any, pageProps: any) => {
     <Layout>
       <NextSeo
         title="Become a Claude Code Power-User"
-        description="Join John Lindquist for a hands-on, technical workshop to fully understand building production-grade apps with Claude using TypeScript scripting, automation, and integrations."
+        description="Join John Lindquist for a hands-on, technical workshop to transform into a Claude Code power user using TypeScript scripting, automation, and integrations."
         openGraph={{
           images: [
             {


### PR DESCRIPTION
## Summary

This PR updates the workshop copy from "Production-Grade" to "Transform into a Claude Code Power User" to better align with the theme of going beyond the basics and unlocking hidden power.

## Changes

- Updated hero title in `Hero.tsx`
- Updated titles in `active-sale.tsx` (2 instances)
- Updated title in `contact-form.tsx`
- Updated meta description in `index.tsx`
- Updated supporting copy to match the new theme

## Why this change?

The previous "Production-Grade" copy didn't capture the journey of discovery and mastery that's central to the workshop's narrative. The new copy better reflects:
- The transformation from casual user to power user
- The "80% untapped potential" theme
- The focus on advanced techniques and hidden features

![transformation](https://media.giphy.com/media/3o7TKNdH1VMK0GhPaM/giphy.gif)

## Testing

- ✅ Verified all instances of the old copy have been updated
- ✅ Checked that the new copy flows well with surrounding content
- ✅ Ensured consistency across all components